### PR TITLE
[⚙️ chore] pnpm 설치 강제하기 (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.66.9",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

pnpm 이외의 패키지 매니저로 패키지를 설치 및 추가하는 것을 막고자 강제 스크립트를 추가했어요.

## 🔧 변경 사항

- pnpm 강제하기 스크립트 추가

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

When you use pnpm on a project, you don't want others to accidentally run `npm install` or `yarn`. To prevent devs from using other package managers, you can add the following `preinstall` script to your `package.json`:

```bash
{
	"scripts": {
		"preinstall": "npx only-allow pnpm"
	}
}
```

Now, whenever someone runs `npm install` or `yarn`, they'll get an error instead and installation will not proceed.
