### PR TITLE
[✨ feat] 상품 더 보기 컴포넌트 제작 (#65)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
         className={`${pretendard.variable} font-pretendard flex min-h-screen flex-col items-center`}
       >
         <Header />
-        <div className="w-full max-w-7xl flex-1">
+        <div className="w-full max-w-[1280px] flex-1">
           <main>{children}</main>
         </div>
         <Footer />

--- a/src/components/common/button/MoreViewButton.tsx
+++ b/src/components/common/button/MoreViewButton.tsx
@@ -1,0 +1,16 @@
+import Button from './Button';
+
+const MoreViewButton = () => {
+  return (
+    <Button
+      className="!py-lg text-text-secondary w-full text-xl"
+      variant="transparent"
+      icon="chevronsDown"
+      iconPosition="right"
+    >
+      더보기
+    </Button>
+  );
+};
+
+export default MoreViewButton;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,6 +2,7 @@ export { default as Button } from './button/Button';
 export { default as ClickTextButton } from './button/ClickTextButton';
 export { default as IconButton } from './button/IconButton';
 export { default as LogoutButton } from './button/LogoutButton';
+export { default as MoreViewButton } from './button/MoreViewButton';
 export * from './header';
 export { default as Input } from './Input';
 export { default as Icon } from './Icon';

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -6,7 +6,7 @@ import FooterCustomerInfo from './FooterCustomerInfo';
 const Footer = () => {
   return (
     <footer className="py-6xl bg-bg-tertiary w-full">
-      <div className="mx-auto max-w-7xl">
+      <div className="mx-auto max-w-[1280px]">
         <div className="space-y-3xl pb-6xl border-border-tertiaryHover border-b-[0.5px]">
           <div className="space-y-4xl">
             <FooterLogo />

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -8,7 +8,7 @@ import TextHeader from './TextHeader';
 const Header = () => {
   return (
     <header className="pt-2xl pb-4xl border-border-secondary flex w-full flex-col border-b">
-      <div className="mx-auto w-full max-w-7xl">
+      <div className="mx-auto w-full max-w-[1280px]">
         <nav className="mb-lg flex justify-end">
           <TextHeader
             country="한국"

--- a/src/stories/button/Button.stories.ts
+++ b/src/stories/button/Button.stories.ts
@@ -121,6 +121,16 @@ export const LikeOff: Story = {
   },
 };
 
+export const MoreView: Story = {
+  args: {
+    variant: 'transparent',
+    icon: 'chevronsDown',
+    iconPosition: 'right',
+    children: '더보기',
+    className: '!py-lg text-text-secondary w-full text-xl',
+  },
+};
+
 export const WithIcon: Story = {
   args: {
     variant: 'primary',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품에 있는 '더 보기' 버튼을 제작했어요.

## 🔧 변경 사항

- '더 보기' 버튼을 추가했어요.
- 스토리북에도 추가로 작성했어요.
- 레이아웃 너비값을 임시로 픽셀로 지정했어요. 

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

피그마에 정의된 `outline` variant는 필요 없다고 하셔서 한 가지 베리언트만 사용했습니다 ~
