### PR TITLE
[✨ feat] 위로 가기 버튼 추가 (#67)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 
-import { Header, Footer } from '@/components';
+import { Header, Footer, ScrollToTopButton } from '@/components';
 import '@/styles/globals.css';
 
 if (process.env.NODE_ENV === 'development') {
@@ -34,10 +34,11 @@ export default function RootLayout({
         className={`${pretendard.variable} font-pretendard flex min-h-screen flex-col items-center`}
       >
         <Header />
-        <div className="w-full max-w-[1280px] flex-1">
+        <div className="relative w-full max-w-[1280px] flex-1">
           <main>{children}</main>
         </div>
         <Footer />
+        <ScrollToTopButton />
       </body>
     </html>
   );

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -39,7 +39,7 @@ const Button = ({
   iconProps,
 }: ButtonProps) => {
   const defaultClass =
-    'px-lg py-md flex gap-sm rounded-lg justify-center items-center cursor-pointer';
+    'px-lg py-md flex gap-sm rounded-lg transition-all duration-300 justify-center items-center cursor-pointer';
   const variantClass = {
     primary:
       'bg-bg-primaryInteraction text-text-inverse hover:bg-bg-primaryHover active:bg-bg-primaryPressed',

--- a/src/components/common/button/ScrollToTopButton.tsx
+++ b/src/components/common/button/ScrollToTopButton.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { cn } from '@/utils';
+import Button from './Button';
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        'px-lg fixed right-0 bottom-10 transition-all duration-300 ease-in-out',
+        isVisible
+          ? 'translate-y-0 opacity-100'
+          : 'pointer-events-none translate-y-10 opacity-0',
+      )}
+    >
+      <Button
+        icon="upArrow"
+        iconProps={{
+          width: 32,
+          height: 32,
+          style: {
+            minWidth: '32px',
+            minHeight: '32px',
+            width: '32px',
+            height: '32px',
+          },
+        }}
+        onClick={scrollToTop}
+        className="bg-bg-primary text-text-primary hover:text-text-inverse active:text-text-inverse shadow-custom-effect h-32 w-16 rounded-full"
+      />
+    </div>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { default as ClickTextButton } from './button/ClickTextButton';
 export { default as IconButton } from './button/IconButton';
 export { default as LogoutButton } from './button/LogoutButton';
 export { default as MoreViewButton } from './button/MoreViewButton';
+export { default as ScrollToTopButton } from './button/ScrollToTopButton';
 export * from './header';
 export { default as Input } from './Input';
 export { default as Icon } from './Icon';

--- a/src/stories/button/Button.stories.ts
+++ b/src/stories/button/Button.stories.ts
@@ -147,3 +147,22 @@ export const IconRight: Story = {
     iconPosition: 'right',
   },
 };
+
+export const ScrollToTop: Story = {
+  args: {
+    variant: 'primary',
+    icon: 'upArrow',
+    iconProps: {
+      width: 32,
+      height: 32,
+      style: {
+        minWidth: '32px',
+        minHeight: '32px',
+        width: '32px',
+        height: '32px',
+      },
+    },
+    className:
+      'bg-bg-primary text-text-primary hover:text-text-inverse active:text-text-inverse shadow-custom-effect h-32 w-16 rounded-full',
+  },
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,10 +1,9 @@
-@import "tailwindcss";
-@import "../styles/token/colors/primitive.css";
-@import "../styles/token/colors/scale.css";
-@import "../styles/token/colors/semantic.css";
-@import "../styles/token/border.css";
-@import "../styles/token/spacing.css";
-
+@import 'tailwindcss';
+@import '../styles/token/colors/primitive.css';
+@import '../styles/token/colors/scale.css';
+@import '../styles/token/colors/semantic.css';
+@import '../styles/token/border.css';
+@import '../styles/token/spacing.css';
 
 @layer base {
   *,
@@ -17,6 +16,10 @@
 }
 @theme {
   --font-pretendard: var(--font-pretendard);
+
+  --shadow-custom-effect:
+    0px 4px 8px 0px var(--color-shadow-cast),
+    0px 0px 4px 0px var(--color-shadow-core);
 }
 
 :root {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

위로 가기 버튼을 추가했어요. 

## 🔧 변경 사항

- 버튼 컴포넌트에 `transition`, `duration`을 추가했어요.
- 위로 가기 버튼을 제작했어요.
- 300px이상 스크롤 시 위로 가기 버튼이 애니메이션을 통해 나타나도록 처리했어요. 다시 300px 미만이면 보이지 않도록 했어요.
- 이 버튼에 사용되는 그림자 이펙트가 토큰화 되어 있지 않아 추가했어요.

## 📸 스크린샷

스토리북 확인 바랍니다!

## 📄 기타

피그마 상으로는 1280px 내부에 위로 가기 버튼이 있습니다. 1280px 내부로 들여보내려 했는데 `fixed` 되지 않았습니다. 
그래서 `ScrollToTop` 컴포넌트 내부에서 화면 너비를 계산해 리사이징되도록 해보았는데 그렇다면 리사이징이 될 때마다 리렌더링 돼요.

그래서 일단 1280px 외부에 배치 시켜 두었습니다. 디자이너님과 리뷰어님들의 생각이 궁금합니다.
