### PR TITLE
[🔧 fix] spacing 디자인 토큰 제거 및 padding, margin, gap 토큰 분리

### DIFF
--- a/src/styles/token/spacing.css
+++ b/src/styles/token/spacing.css
@@ -1,16 +1,73 @@
 @import "tailwindcss";
 
+/** 
+  * Spacing
+  * 
+  * The spacing scale is based on a 4px grid. 
+  * The scale is used for margin, padding, and gap utilities.
+  * 
+  * @see https://tailwindcss.com/docs/customizing-spacing
+  * 
+  * Theme variable namespaces
+  * --spacing-* : padding, margin, gap, max-height, max-width, height, width
+  * --padding-* : padding
+  * --margin-* : margin
+  * --gap-* : gap
+  * @see https://tailwindcss.com/docs/theme#referencing-theme-values
+  */
+
+:root {
+  --space-2xs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 28px;
+  --space-2xl: 32px;
+  --space-3xl: 36px;
+  --space-4xl: 40px;
+  --space-5xl: 48px;
+  --space-6xl: 60px;
+  --space-7xl: 80px;
+}
+
 @theme {
-    --spacing-2xs: 4px;
-    --spacing-xs: 8px;
-    --spacing-sm: 12px;
-    --spacing-md: 16px;
-    --spacing-lg: 24px;
-    --spacing-xl: 28px;
-    --spacing-2xl: 32px;
-    --spacing-3xl: 36px;
-    --spacing-4xl: 40px;
-    --spacing-5xl: 48px;
-    --spacing-6xl: 60px;
-    --spacing-7xl: 80px;
+    --padding-2xs: var(--space-2xs);
+    --padding-xs: var(--space-xs);
+    --padding-sm: var(--space-sm);
+    --padding-md: var(--space-md);
+    --padding-lg: var(--space-lg);
+    --padding-xl: var(--space-xl);
+    --padding-2xl: var(--space-2xl);
+    --padding-3xl: var(--space-3xl);
+    --padding-4xl: var(--space-4xl);
+    --padding-5xl: var(--space-5xl);
+    --padding-6xl: var(--space-6xl);
+    --padding-7xl: var(--space-7xl);
+
+    --margin-2xs: var(--space-2xs);
+    --margin-xs: var(--space-xs);
+    --margin-sm: var(--space-sm);
+    --margin-md: var(--space-md);
+    --margin-lg: var(--space-lg);
+    --margin-xl: var(--space-xl);
+    --margin-2xl: var(--space-2xl);
+    --margin-3xl: var(--space-3xl);
+    --margin-4xl: var(--space-4xl);
+    --margin-5xl: var(--space- 5xl);
+    --margin-6xl: var(--space-6xl);
+    --margin-7xl: var(--space-7xl);
+
+    --gap-2xs: var(--space-2xs);
+    --gap-xs: var(--space-xs);
+    --gap-sm: var(--space-sm);
+    --gap-md: var(--space-md);
+    --gap-lg: var(--space-lg);
+    --gap-xl: var(--space-xl);
+    --gap-2xl: var(--space-2xl);
+    --gap-3xl: var(--space-3xl);
+    --gap-4xl: var(--space-4xl);
+    --gap-5xl: var(--space-5xl);
+    --gap-6xl: var(--space-6xl);
+    --gap-7xl: var(--space-7xl);
   }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- spacing 토큰이 padding, margin, gap 유틸리티 클래스 뿐만아니라 max-w-, max-h- 등의 기본 유틸리티 클래스 값을 오버라이팅하므로 padding, margin, gap 만 적용되도록 수정

## 🔧 변경 사항

- styles/token/spacing.css 수정
- `--spacing-*` tailwindCSS 변수는 많은 유틸클래스의 기본값을 변화시키므로 `--space-*` 컨벤션을 사용, 유틸클래스의 토큰으로 적용되지 않으므로 :root 내에서 정의
- 명확한 유틸클래스 사용하도록 `--padding-*`, `--margin-*`, `--gap-*` tailwindCSS 변수 사용

```css
@import "tailwindcss";

:root {
  --space-2xs: 4px;
  --space-xs: 8px;
  --space-sm: 12px;
  --space-md: 16px;
  --space-lg: 24px;
  --space-xl: 28px;
  --space-2xl: 32px;
  --space-3xl: 36px;
  --space-4xl: 40px;
  --space-5xl: 48px;
  --space-6xl: 60px;
  --space-7xl: 80px;
}

@theme {
    --padding-2xs: var(--space-2xs);
    --padding-xs: var(--space-xs);
    --padding-sm: var(--space-sm);
    --padding-md: var(--space-md);
    --padding-lg: var(--space-lg);
    --padding-xl: var(--space-xl);
    --padding-2xl: var(--space-2xl);
    --padding-3xl: var(--space-3xl);
    --padding-4xl: var(--space-4xl);
    --padding-5xl: var(--space-5xl);
    --padding-6xl: var(--space-6xl);
    --padding-7xl: var(--space-7xl);

    --margin-2xs: var(--space-2xs);
    --margin-xs: var(--space-xs);
    --margin-sm: var(--space-sm);
    --margin-md: var(--space-md);
    --margin-lg: var(--space-lg);
    --margin-xl: var(--space-xl);
    --margin-2xl: var(--space-2xl);
    --margin-3xl: var(--space-3xl);
    --margin-4xl: var(--space-4xl);
    --margin-5xl: var(--space- 5xl);
    --margin-6xl: var(--space-6xl);
    --margin-7xl: var(--space-7xl);

    --gap-2xs: var(--space-2xs);
    --gap-xs: var(--space-xs);
    --gap-sm: var(--space-sm);
    --gap-md: var(--space-md);
    --gap-lg: var(--space-lg);
    --gap-xl: var(--space-xl);
    --gap-2xl: var(--space-2xl);
    --gap-3xl: var(--space-3xl);
    --gap-4xl: var(--space-4xl);
    --gap-5xl: var(--space-5xl);
    --gap-6xl: var(--space-6xl);
    --gap-7xl: var(--space-7xl);
  }
```

## 📸 스크린샷



## 📄 기타

사용하는 쪽에서는 수정할 필요가 없습니다.
