### PR TITLE
[🔧 fix] lefthook 검증에서 css 파일도 추가 (#73)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
       run: pnpm exec eslint {staged_files} --fix && echo "ESLint ran on {staged_files}"
       stage_fixed: true
     prettier:
-      glob: '**/*.{js,ts,jsx,tsx,json,yaml,md}'
+      glob: '**/*.{js,ts,jsx,tsx,json,yaml,md,css}'
       run: pnpm exec prettier --write {staged_files}
       stage_fixed: true
 commit-msg:


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

lefthook에서 prettier에 css 확장자도 검증되도록 추가했어요.

## 🔧 변경 사항

- prettier에 css 확장자를 추가했어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
