### PR TITLE
[♻️ refactor] 폰트 디자인 토큰 정의 및 font 커스텀 클래스 리팩토링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body
-        className={`${pretendard.variable} font-pretendard flex min-h-screen flex-col items-center`}
+        className={`${pretendard.variable} font-pretendard font-style-paragraph flex min-h-screen flex-col items-center`}
       >
         <Header />
         <div className="relative w-full max-w-[1280px] flex-1">

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,3 +1,5 @@
+@import 'tailwindcss';
+
 @utility font-style-title {
   font-size: var(--text-5xl);
   line-height: var(--leading-3xl);

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,71 +1,71 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @utility font-style-title {
-  font-size:  40px;
-  line-height: 36px;
-  letter-spacing: 1.5px;
-  font-weight: 600;
+  font-size: var(--text-5xl);
+  line-height: var(--leading-3xl);
+  letter-spacing: var(--tracking-expanded);
+  font-weight: var(--font-weight-semibold);
 
   @media (max-width: 768px) {
-      font-size: 24px;
-      line-height: 36px;
-      letter-spacing: -0.2px;
-      font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--leading-3xl);
+    letter-spacing: var(--tracking-expanded);
+    font-weight: var(--font-weight-semibold);
   }
 }
 
 @utility font-style-heading {
-  font-size:  24px;
-  line-height: 36px;
-  letter-spacing: -0.2px;
-  font-weight: 600;
+  font-size: var(--text-2xl);
+  line-height: var(--leading-3xl);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
 
   @media (max-width: 768px) {
-      font-size: 20px;
-      line-height: 32px;
-      letter-spacing: -0.2px;
-      font-weight: 600;
+    font-size: var(--text-xl);
+    line-height: var(--leading-3xl);
+    letter-spacing: var(--tracking-tight);
+    font-weight: var(--font-weight-semibold);
   }
 }
 
 @utility font-style-subHeading {
-  font-size:  20px;
-  line-height: 32px;
-  letter-spacing: -0.2px;
-  font-weight: 600;
+  font-size: var(--text-xl);
+  line-height: var(--leading-2xl);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
 
   @media (max-width: 768px) {
-      font-size: 20px;
-      line-height: 32px;
-      letter-spacing: -0.2px;
-      font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--leading-2xl);
+    letter-spacing: var(--tracking-tight);
+    font-weight: var(--font-weight-semibold);
   }
 }
 
 @utility font-style-paragraph {
-  font-size:  16px;
-  line-height: 24px;
-  letter-spacing: -0.4px;
-  font-weight: 400;
+  font-size: var(--text-base);
+  line-height: var(--leading-lg);
+  letter-spacing: var(--tracking-tighter);
+  font-weight: var(--font-weight-normal);
 
   @media (max-width: 768px) {
-      font-size: 16px;
-      line-height: 24px;
-      letter-spacing: -0.4px;
-      font-weight: 400;
+    font-size: var(--text-sm);
+    line-height: var(--leading-lg);
+    letter-spacing: var(--tracking-tighter);
+    font-weight: var(--font-weight-normal);
   }
 }
 
 @utility font-style-info {
-  font-size:  14px;
-  line-height: 24px;
-  letter-spacing: -0.4px;
-  font-weight: 400;
+  font-size: var(--text-sm);
+  line-height: var(--leading-lg);
+  letter-spacing: var(--tracking-tighter);
+  font-weight: var(--font-weight-normal);
 
   @media (max-width: 768px) {
-      font-size: 14px;
-      line-height: 24px;
-      letter-spacing: -0.4px;
-      font-weight: 400;
+    font-size: var(--text-sx);
+    line-height: var(--leading-lg);
+    letter-spacing: var(--tracking-tighter);
+    font-weight: var(--font-weight-normal);
   }
 }

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,5 +1,3 @@
-@import 'tailwindcss';
-
 @utility font-style-title {
   font-size: var(--text-5xl);
   line-height: var(--leading-3xl);

--- a/src/styles/token/font/primitive.css
+++ b/src/styles/token/font/primitive.css
@@ -1,0 +1,104 @@
+@import 'tailwindcss';
+
+:root {
+  /** font famaily */
+  --font-sans: 'Pretendard';
+  --font-serif: 'Noto Serif';
+
+  /** font size */
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 28px;
+  --text-4xl: 36px;
+  --text-5xl: 40px;
+  --text-6xl: 48px;
+  --text-7xl: 60px;
+
+  /** line height */
+  --leading-xs: 16px;
+  --leading-sm: 20px;
+  --leading-base: 24px;
+  --leading-lg: 28px;
+  --leading-xl: 32px;
+  --leading-2xl: 40px;
+  --leading-3xl: 48px;
+  --leading-4xl: 56px;
+  --leading-5xl: 64px;
+  --leading-6xl: 72px;
+  --leading-7xl: 80px;
+  --leading-none: 1;
+
+  /** letter spacing */
+  --tracking-tighter: -0.4px;
+  --tracking-tight: -0.2px;
+  --tracking-normal: 0px;
+  --tracking-wide: 1px;
+  --tracking-wider: 0.2px;
+  --tracking-widest: 0.4px;
+  --tracking-expanded: 1.5px;
+
+  /** font weight */
+  --font-weight-thin: 100;
+  --font-weight-extralight: 200;
+  --font-weight-light: 300;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+  --font-weight-black: 900;
+  --font-weight-extrablack: 950;
+}
+
+@theme {
+  --font-sans: var(--font-sans);
+  --font-serif: var(--font-serif);
+
+  --text-xs: var(--text-xs);
+  --text-sm: var(--text-sm);
+  --text-base: var(--text-base);
+  --text-lg: var(--text-lg);
+  --text-xl: var(--text-xl);
+  --text-2xl: var(--text-2xl);
+  --text-3xl: var(--text-3xl);
+  --text-4xl: var(--text-4xl);
+  --text-5xl: var(--text-5xl);
+  --text-6xl: var(--text-6xl);
+  --text-7xl: var(--text-7xl);
+
+  --leading-xs: var(--leading-xs);
+  --leading-sm: var(--leading-sm);
+  --leading-base: var(--leading-base);
+  --leading-lg: var(--leading-lg);
+  --leading-xl: var(--leading-xl);
+  --leading-2xl: var(--leading-2xl);
+  --leading-3xl: var(--leading-3xl);
+  --leading-4xl: var(--leading-4xl);
+  --leading-5xl: var(--leading-5xl);
+  --leading-6xl: var(--leading-6xl);
+  --leading-7xl: var(--leading-7xl);
+  --leading-none: var(--leading-none);
+
+  --tracking-tighter: var(--tracking-tighter);
+  --tracking-tight: var(--tracking-tight);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+  --tracking-widest: var(--tracking-widest);
+  --tracking-expanded: var(--tracking-expanded);
+
+  --font-weight-thin: var(--font-weight-thin);
+  --font-weight-extralight: var(--font-weight-extralight);
+  --font-weight-light: var(--font-weight-light);
+  --font-weight-normal: var(--font-weight-normal);
+  --font-weight-medium: var(--font-weight-medium);
+  --font-weight-semibold: var(--font-weight-semibold);
+  --font-weight-bold: var(--font-weight-bold);
+  --font-weight-extrabold: var(--font-weight-extrabold);
+  --font-weight-black: var(--font-weight-black);
+  --font-weight-extrablack: var(--font-weight-extrablack);
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 피그마와 font 디자인 토큰 협의 완료하여 font 디자인 토큰 생성
- PR #70 에서 정의한 font 커스텀 클래스의 속성 값을 디자인 토큰으로 적용

## 🔧 변경 사항

- styles/token/font/primitive.css 파일에 font css 전역 변수와 taliwindCSS 유틸클래스를 위한 토큰 정의
- styles/fonts.css 파일 리팩토링

## 📸 스크린샷



## 📄 기타

UI 변경 및 클래스명 변경 사항은 없습니다. 

참고 전역 변수로서 사용하기 위해서 `:root {}` 내에서 정의하였고
tailwindCSS 유틸클래스에 적용하기 위해서 `@theme {}` 내에서 다시 정의 했습니다. 

더 좋은 방법이 있으면 코멘트 부탁드립니다. 

그리고 협의된대로 폰트 스타일을 적용할 때는 정의된 커스텀 클래스만 사용하고 그외의 경우는 슬랙으로 상황 공유 부탁드립니다!