### PR TITLE
[✨ feat] 드롭다운 컴포넌트 구현 (#94)

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+
+import { cn } from '@/utils';
+import Icon from './Icon';
+import RadioOption from './RadioOption';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface DropdownProps {
+  options: Option[];
+  placeholder?: string;
+  onChange?: (option: Option) => void;
+  defaultValue?: Option | null;
+}
+
+const Dropdown = ({
+  options,
+  placeholder = '옵션 없음',
+  onChange,
+  defaultValue,
+}: DropdownProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [selectedOption, setSelectedOption] = useState<Option | null>(
+    defaultValue || null,
+  );
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleOptionClick = (option: Option): void => {
+    setSelectedOption(option);
+    setIsOpen(false);
+    if (onChange) {
+      onChange(option);
+    }
+  };
+
+  const toggleDropdown = (): void => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="relative w-full" ref={dropdownRef}>
+      <div
+        className="border-border-primary py-sm px-lg bg-bg-primary flex cursor-pointer items-center justify-between border"
+        onClick={toggleDropdown}
+      >
+        <span
+          className={cn(
+            selectedOption ? 'text-text-info' : 'text-text-secondary',
+          )}
+        >
+          {selectedOption ? selectedOption.label : placeholder}
+        </span>
+        <Icon
+          iconName="chevronsDown"
+          fill="text-icon-secondary"
+          className={cn(
+            'transtion-transform duration-300',
+            isOpen && 'rotate-180',
+          )}
+        />
+      </div>
+
+      {isOpen && (
+        <div className="animate-dropdown bg-bg-tertiary gap-2xs border-border-secondary shadow-custom-effect absolute z-10 mt-1 flex max-h-60 w-full origin-top flex-col overflow-y-auto rounded-sm border transition-all duration-300">
+          {options.length > 0 &&
+            options.map((option, index) => (
+              <RadioOption
+                key={index}
+                option={option}
+                isSelected={selectedOption?.value === option.value}
+                onClick={handleOptionClick}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -31,6 +31,7 @@ import {
   ViewIcon,
   XIcon,
   GoogleLogoIcon,
+  RadioIcon,
 } from '../icons';
 
 export const IconMap: Record<
@@ -67,6 +68,7 @@ export const IconMap: Record<
   starHalf: StarHalfIcon,
   starFill: StarFillIcon,
   googleLogo: GoogleLogoIcon,
+  radio: RadioIcon,
 };
 
 interface IconComponentProps extends React.SVGProps<SVGSVGElement> {

--- a/src/components/common/RadioOption.tsx
+++ b/src/components/common/RadioOption.tsx
@@ -17,12 +17,12 @@ interface RadioOptionProps {
 const RadioOption = ({ option, isSelected, onClick }: RadioOptionProps) => {
   return (
     <div
-      className="px-sm py-xs gap-2xs flex cursor-pointer items-center"
+      className="px-sm py-xs gap-2xs flex cursor-pointer items-start"
       onClick={() => onClick(option)}
     >
       <div
         className={cn(
-          'mr-xs flex h-[var(--space-lg)] w-[var(--space-lg)] items-center justify-center rounded-full',
+          'mr-xs flex h-[var(--space-lg)] w-[var(--space-lg)] flex-shrink-0 items-center justify-center rounded-full',
           isSelected
             ? 'bg-bg-primary'
             : 'border-border-tertiaryInteraction border-2',
@@ -32,7 +32,7 @@ const RadioOption = ({ option, isSelected, onClick }: RadioOptionProps) => {
       </div>
       <span
         className={cn(
-          'font-style-paragraph',
+          'font-style-paragraph break-words',
           isSelected ? 'text-text-info' : 'text-text-secondary',
         )}
       >

--- a/src/components/common/RadioOption.tsx
+++ b/src/components/common/RadioOption.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { cn } from '@/utils';
+import Icon from './Icon';
+
+interface OptionItem {
+  value: string;
+  label: string;
+}
+
+interface RadioOptionProps {
+  option: OptionItem;
+  isSelected: boolean;
+  onClick: (option: OptionItem) => void;
+}
+
+const RadioOption = ({ option, isSelected, onClick }: RadioOptionProps) => {
+  return (
+    <div
+      className="px-sm py-xs gap-2xs flex cursor-pointer items-center"
+      onClick={() => onClick(option)}
+    >
+      <div
+        className={cn(
+          'mr-xs flex h-[var(--space-lg)] w-[var(--space-lg)] items-center justify-center rounded-full',
+          isSelected
+            ? 'bg-bg-primary'
+            : 'border-border-tertiaryInteraction border-2',
+        )}
+      >
+        {isSelected && <Icon iconName="radio" />}
+      </div>
+      <span
+        className={cn(
+          'font-style-paragraph',
+          isSelected ? 'text-text-info' : 'text-text-secondary',
+        )}
+      >
+        {option.label}
+      </span>
+    </div>
+  );
+};
+
+export default RadioOption;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -9,3 +9,5 @@ export * from './header';
 export { default as Input } from './Input';
 export { default as Icon } from './Icon';
 export { default as Logo } from './Logo';
+export { default as Dropdown } from './Dropdown';
+export { default as RadioOption } from './RadioOption';

--- a/src/components/icons/RadioIcon.tsx
+++ b/src/components/icons/RadioIcon.tsx
@@ -1,0 +1,21 @@
+const RadioIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className="fill-current"
+      {...props}
+    >
+      <path
+        d="M0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12Z"
+        fill="#663EFF"
+      />
+      <circle cx="12" cy="12" r="6" fill="white" />
+    </svg>
+  );
+};
+
+export default RadioIcon;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -28,3 +28,4 @@ export { default as StarGrayIcon } from './StarGrayIcon';
 export { default as StarHalfIcon } from './StarHalfIcon';
 export { default as StarFillIcon } from './StarFillIcon';
 export { default as GoogleLogoIcon } from './GoogleLogoIcon';
+export { default as RadioIcon } from './RadioIcon';

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Dropdown } from '@/components';
+
+const dummyOptions = [
+  { value: 'option1', label: '옵션 1' },
+  { value: 'option2', label: '옵션 2' },
+  { value: 'option3', label: '옵션 3' },
+];
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Dropdown/Dropdown',
+  component: Dropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    options: {
+      description: '드롭다운에 나올 옵션 배열',
+      control: 'object',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    onChange: {
+      action: 'changed',
+    },
+    defaultValue: {
+      control: 'object',
+    },
+  },
+  decorators: [
+    Story => (
+      <div className="w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Dropdown>;
+
+export const Default: Story = {
+  args: {
+    options: dummyOptions,
+    placeholder: '옵션을 선택하세요',
+  },
+};
+
+export const WithDefaultValue: Story = {
+  args: {
+    options: dummyOptions,
+    defaultValue: { value: 'option2', label: '옵션 2' },
+  },
+};
+
+export const ManyOptions: Story = {
+  args: {
+    options: Array.from({ length: 10 }, (_, i) => ({
+      value: `option${i + 1}`,
+      label: `옵션 ${i + 1}`,
+    })),
+    placeholder: '옵션을 선택하세요',
+  },
+};

--- a/src/stories/RadioOption.stories.tsx
+++ b/src/stories/RadioOption.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RadioOption } from '@/components';
+
+const meta: Meta<typeof RadioOption> = {
+  title: 'Option/RadioOption',
+  component: RadioOption,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    option: {
+      description: '라디오 옵션에 표시할 항목',
+      control: 'object',
+    },
+    isSelected: {
+      control: 'boolean',
+    },
+    onClick: {
+      action: 'clicked',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioOption>;
+
+export const Default: Story = {
+  args: {
+    option: { value: 'option1', label: '기본 옵션' },
+    isSelected: false,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    option: { value: 'option1', label: '선택된 옵션' },
+    isSelected: true,
+  },
+};
+
+export const OptionGroup: Story = {
+  render: args => (
+    <div className="gap-xs flex flex-col">
+      <RadioOption
+        option={{ value: 'option1', label: '첫 번째 옵션' }}
+        isSelected={true}
+        onClick={args.onClick}
+      />
+      <RadioOption
+        option={{ value: 'option2', label: '두 번째 옵션' }}
+        isSelected={false}
+        onClick={args.onClick}
+      />
+    </div>
+  ),
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -41,6 +41,19 @@
   --shadow-custom-effect:
     0px 4px 8px 0px var(--color-shadow-cast),
     0px 0px 4px 0px var(--color-shadow-core);
+
+  --animate-dropdown: dropdown 0.2s ease-out forwards;
+
+  @keyframes dropdown {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 body {

--- a/src/types/iconType.ts
+++ b/src/types/iconType.ts
@@ -28,4 +28,5 @@ export type IconType =
   | 'hamburgerbar'
   | 'starGray'
   | 'starHalf'
-  | 'starFill';
+  | 'starFill'
+  | 'radio';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

옵션 선택 시 필요한 드롭다운 컴포넌트를 제작했어요.

## 🔧 변경 사항

- `RadioOption` 컴포넌트를 제작하고 스토리북을 작성했어요.
- `Dropdown` 컴포넌트를 제작하고 스토리북을 작성했어요.
- 드롭다운 시 펼쳐지는 항목들은 `RadioOption` 컴포넌트로 만들었어요.
- 옵션 선택 시 라디오 버튼의 활성화 아이콘인 `RadioIcon`을 추가했어요.
- 드롭다운 시 생겨나는 드롭다운 애니메이션 토큰을 추가했어요.

## 📸 스크린샷

스토리북을 통해 확인할 수 있습니다.

## 📄 기타

`Option` 컴포넌트를 `check`, `default`, `radio` 타입에 따라 나누어 보려고 했는데 `radio` 옵션밖에 쓰이는 것 같아 일단 우선적인 범위 내에서 하는 것이 맞는 것 같아 `RadioOption`만 제작했어요. 
