### PR TITLE
[✨ feat] 상품 상세 페이지 상단 주요 내용 담당 컴포넌트 제작 (#100)

### DIFF
--- a/src/app/(root)/products/[productId]/page.tsx
+++ b/src/app/(root)/products/[productId]/page.tsx
@@ -2,11 +2,11 @@ import { fetchProductById } from '@/services';
 import { RecommendProductList, ProductDetailItem } from '@/components';
 
 interface Params {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ productId: string }>;
 }
 
 export async function generateMetadata({ params }: Params) {
-  const { slug: productId } = await params;
+  const { productId } = await params;
   const product = await fetchProductById(productId);
 
   if (!product) return;
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Params) {
 }
 
 const ProductDetailPage = async ({ params }: Params) => {
-  const { slug: productId } = await params;
+  const { productId } = await params;
   const product = await fetchProductById(productId);
 
   return (

--- a/src/app/(root)/products/[slug]/page.tsx
+++ b/src/app/(root)/products/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import { fetchProductById } from '@/services';
+import { RecommendProductList, ProductDetailItem } from '@/components';
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Params) {
+  const { slug: productId } = await params;
+  const product = await fetchProductById(productId);
+
+  if (!product) return;
+
+  return {
+    title: product.name,
+    siteName: 'Jihye',
+    description: product.description,
+    openGraph: {
+      title: product.name,
+      images: product.titleUrl,
+      type: 'website',
+    },
+  };
+}
+
+const ProductDetailPage = async ({ params }: Params) => {
+  const { slug: productId } = await params;
+  const product = await fetchProductById(productId);
+
+  return (
+    <div className="gap-5xl flex flex-col">
+      <ProductDetailItem {...product} />
+
+      <RecommendProductList categoryName="식료품" />
+
+      <section className="bg-bg-secondary font-style-subHeading text-text-tertiary flex h-[640px] items-center justify-center overflow-y-auto">
+        챗봇영역
+      </section>
+
+      <section className="gap-md flex flex-col">
+        <h2 className="font-style-subHeading text-text-primary">상품 정보</h2>
+        <div className="bg-bg-secondary font-style-subHeading text-text-tertiary flex h-[640px] items-center justify-center overflow-y-auto">
+          상품정보영역
+        </div>
+      </section>
+
+      <section className="gap-md flex flex-col">
+        <div>
+          <h2 className="font-style-subHeading text-text-primary">상품 리뷰</h2>
+          <p className="text-text-secondary font-style-paragraph">
+            동일한 상품에 대한 고객들의 의견입니다.
+          </p>
+        </div>
+        <div className="bg-bg-secondary font-style-subHeading text-text-tertiary flex h-[640px] items-center justify-center overflow-y-auto">
+          리뷰영역
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProductDetailPage;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -86,7 +86,7 @@ const Dropdown = ({
       </div>
 
       {isOpen && (
-        <div className="animate-dropdown bg-bg-tertiary gap-2xs border-border-secondary shadow-custom-effect absolute z-10 mt-[var(--space-xs)] flex max-h-60 w-full origin-top flex-col overflow-y-auto rounded-sm border transition-all duration-300">
+        <div className="animate-dropdown bg-bg-tertiary gap-2xs border-border-secondary shadow-custom-effect mt-xs absolute z-10 flex max-h-60 w-full origin-top flex-col overflow-y-auto rounded-sm border transition-all duration-300">
           {options.length > 0 &&
             options.map((option, index) => (
               <RadioOption

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -61,7 +61,7 @@ const Dropdown = ({
   return (
     <div className="relative w-full" ref={dropdownRef}>
       <div
-        className="border-border-primary py-sm px-lg bg-bg-primary flex cursor-pointer items-center justify-between border"
+        className="border-border-primary py-sm px-lg bg-bg-primary flex cursor-pointer items-center justify-between rounded-sm border"
         onClick={toggleDropdown}
       >
         <span
@@ -82,7 +82,7 @@ const Dropdown = ({
       </div>
 
       {isOpen && (
-        <div className="animate-dropdown bg-bg-tertiary gap-2xs border-border-secondary shadow-custom-effect absolute z-10 mt-1 flex max-h-60 w-full origin-top flex-col overflow-y-auto rounded-sm border transition-all duration-300">
+        <div className="animate-dropdown bg-bg-tertiary gap-2xs border-border-secondary shadow-custom-effect absolute z-10 mt-[var(--space-xs)] flex max-h-60 w-full origin-top flex-col overflow-y-auto rounded-sm border transition-all duration-300">
           {options.length > 0 &&
             options.map((option, index) => (
               <RadioOption

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -64,21 +64,25 @@ const Dropdown = ({
         className="border-border-primary py-sm px-lg bg-bg-primary flex cursor-pointer items-center justify-between rounded-sm border"
         onClick={toggleDropdown}
       >
-        <span
-          className={cn(
-            selectedOption ? 'text-text-info' : 'text-text-secondary',
-          )}
-        >
-          {selectedOption ? selectedOption.label : placeholder}
-        </span>
-        <Icon
-          iconName="chevronsDown"
-          fill="text-icon-secondary"
-          className={cn(
-            'transtion-transform duration-300',
-            isOpen && 'rotate-180',
-          )}
-        />
+        <div className="line-clamp-2 flex-1 overflow-hidden pr-2 break-words">
+          <span
+            className={cn(
+              selectedOption ? 'text-text-info' : 'text-text-secondary',
+            )}
+          >
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+        </div>
+        <div className="flex-shrink-0">
+          <Icon
+            iconName="chevronsDown"
+            fill="text-icon-secondary"
+            className={cn(
+              'transtion-transform duration-300',
+              isOpen && 'rotate-180',
+            )}
+          />
+        </div>
       </div>
 
       {isOpen && (

--- a/src/components/common/button/ScrollToTopButton.tsx
+++ b/src/components/common/button/ScrollToTopButton.tsx
@@ -32,7 +32,7 @@ const ScrollToTopButton = () => {
   return (
     <div
       className={cn(
-        'px-lg fixed right-0 bottom-10 transition-all duration-300 ease-in-out',
+        'px-lg fixed right-0 bottom-10 z-10 transition-all duration-300 ease-in-out',
         isVisible
           ? 'translate-y-0 opacity-100'
           : 'pointer-events-none translate-y-10 opacity-0',
@@ -52,7 +52,7 @@ const ScrollToTopButton = () => {
         }}
         onClick={scrollToTop}
         variant="primaryShadow"
-        className="h-32 w-16 rounded-full"
+        className="h-16 w-8 rounded-full md:h-32 md:w-16"
       />
     </div>
   );

--- a/src/components/icons/RadioIcon.tsx
+++ b/src/components/icons/RadioIcon.tsx
@@ -11,7 +11,7 @@ const RadioIcon = (props: React.SVGProps<SVGSVGElement>) => {
     >
       <path
         d="M0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12Z"
-        fill="#663EFF"
+        fill="var(--color-violet-500)"
       />
       <circle cx="12" cy="12" r="6" fill="white" />
     </svg>

--- a/src/components/products/RecommendCarousel.tsx
+++ b/src/components/products/RecommendCarousel.tsx
@@ -72,7 +72,7 @@ const RecommendCarousel = ({ products }: { products?: Product[] }) => {
   };
 
   return (
-    <ul className="pb-10">
+    <ul className="pb-lg">
       <Slider {...settings}>{renderItems()}</Slider>
     </ul>
   );

--- a/src/components/products/RecommendProductList.tsx
+++ b/src/components/products/RecommendProductList.tsx
@@ -15,8 +15,8 @@ const RecommendProductList = async ({
 
   return (
     <Suspense fallback={<RecommendProductListSkeleton />}>
-      <div className="gap-3xl py-xl pb-xs border-border-secondary flex flex-col border-b">
-        <h2 className="font-style-subHeading text-brand-gradient text-center">
+      <div className="gap-3xl py-xs border-border-secondary flex flex-col border-y">
+        <h2 className="font-style-subHeading pt-xl text-brand-gradient text-center">
           {PRODUCTS_CONSTANTS.getRecommendListTitle(categoryName)}
         </h2>
         <RecommendCarousel products={productItems} />

--- a/src/components/products/index.ts
+++ b/src/components/products/index.ts
@@ -6,3 +6,4 @@ export { default as RecommendProductList } from './RecommendProductList';
 export { default as RecommendCarousel } from './RecommendCarousel';
 export { default as ProductListSkeleton } from './skeleton/ProductListSkeleton';
 export { default as RecommendProductSkeleton } from './skeleton/RecommendProductSkeleton';
+export { default as ProductDetailItem } from './product-detail/ProductDetailItem';

--- a/src/components/products/product-detail/ProductActions.tsx
+++ b/src/components/products/product-detail/ProductActions.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@/components';
+
+const ProductActions = () => {
+  return (
+    <div className="gap-sm grid grid-cols-2">
+      <Button
+        variant="secondaryOutline"
+        className="font-style-subHeading flex-auto"
+      >
+        장바구니 담기
+      </Button>
+      <Button className="font-style-subHeading flex-auto">구매하기</Button>
+    </div>
+  );
+};
+
+export default ProductActions;

--- a/src/components/products/product-detail/ProductDetailItem.tsx
+++ b/src/components/products/product-detail/ProductDetailItem.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+
+import { calculateDiscountRate } from '@/utils';
+import type { Product, OptionValue } from '@/types';
+import ProductHeader from './ProductHeader';
+import ProductOptions from './ProductOptions';
+import ProductPrice from './ProductPrice';
+import ProductQuantity from './ProductQuantity';
+import ProductActions from './ProductActions';
+import ProductThumbnail from '../ProductThumbnail';
+
+const ProductDetailItem = ({
+  titleUrl,
+  name,
+  storeName,
+  freeDelivery,
+  almostOutOfStock,
+  likes,
+  originalPrice,
+  sellingPrice,
+  options,
+  maxPurchaseQuantity,
+}: Product) => {
+  const discountRate = calculateDiscountRate(originalPrice, sellingPrice);
+
+  const [selectedOptions, setSelectedOptions] = useState<
+    Record<string, OptionValue>
+  >({});
+  const [finalPrice, setFinalPrice] = useState<number>(sellingPrice);
+  const [quantity, setQuantity] = useState<number>(1);
+
+  const handleOptionChange = (
+    optionName: string,
+    selectedValue: OptionValue,
+  ) => {
+    const newSelectedOptions = {
+      ...selectedOptions,
+      [optionName]: selectedValue,
+    };
+
+    setSelectedOptions(newSelectedOptions);
+
+    let newPrice = sellingPrice;
+    Object.values(newSelectedOptions).forEach(value => {
+      if (value && value.additionalPrice) {
+        newPrice += value.additionalPrice;
+      }
+    });
+
+    setFinalPrice(newPrice);
+  };
+
+  const handleIncrease = () => {
+    if (quantity < maxPurchaseQuantity) {
+      setQuantity(quantity + 1);
+    }
+  };
+
+  const handleDecrease = () => {
+    if (quantity > 1) {
+      setQuantity(quantity - 1);
+    }
+  };
+
+  return (
+    <div className="gap-md flex flex-col md:flex-row">
+      {/* 상품 이미지 */}
+      <figure className="md:w-1/2">
+        <ProductThumbnail
+          width="w-full"
+          height="h-[350px] sm:h-[630px]"
+          imageUrl={titleUrl}
+          name={name}
+        />
+      </figure>
+
+      {/* 상품 정보  */}
+      <section className="md:w-1/2">
+        <ProductHeader
+          storeName={storeName}
+          name={name}
+          freeDelivery={freeDelivery}
+          almostOutOfStock={almostOutOfStock}
+          likes={likes}
+        />
+        <ProductOptions
+          options={options}
+          handleOptionChange={handleOptionChange}
+        />
+        <ProductPrice
+          originalPrice={originalPrice}
+          finalPrice={finalPrice}
+          quantity={quantity}
+          discountRate={discountRate}
+        />
+        <ProductQuantity
+          quantity={quantity}
+          maxPurchaseQuantity={maxPurchaseQuantity}
+          handleIncrease={handleIncrease}
+          handleDecrease={handleDecrease}
+        />
+        <ProductActions />
+      </section>
+    </div>
+  );
+};
+
+export default ProductDetailItem;

--- a/src/components/products/product-detail/ProductHeader.tsx
+++ b/src/components/products/product-detail/ProductHeader.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+
+import { Button } from '@/components';
+
+interface ProductHeaderProps {
+  storeName: string;
+  name: string;
+  freeDelivery?: boolean;
+  almostOutOfStock?: boolean;
+  likes: number;
+}
+
+const ProductHeader = ({
+  storeName,
+  name,
+  freeDelivery,
+  almostOutOfStock,
+  likes,
+}: ProductHeaderProps) => {
+  return (
+    <header className="md:border-border-secondary pb-lg md:border-b">
+      <Link href="#" className="text-text-secondary font-style-subHeading">
+        {storeName}
+      </Link>
+
+      <h1 className="mb-sm font-style-heading">{name}</h1>
+
+      <div className="mb-md flex gap-2">
+        {freeDelivery && (
+          <div className="bg-bg-successSubtle px-xs rounded-sm">
+            <p className="text-text-success font-style-subHeading">무료배송</p>
+          </div>
+        )}
+
+        {almostOutOfStock && (
+          <div className="bg-bg-infoSubtle px-xs rounded-sm">
+            <p className="text-text-info font-style-subHeading">품절임박</p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-start md:justify-end">
+        <Button
+          icon="heartFill"
+          className="!py-sm !gap-2xs text-icon-visited rounded-full"
+          variant="likeOff"
+        >
+          {likes}
+        </Button>
+      </div>
+    </header>
+  );
+};
+
+export default ProductHeader;

--- a/src/components/products/product-detail/ProductOptions.tsx
+++ b/src/components/products/product-detail/ProductOptions.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Dropdown } from '@/components/common';
+import type { OptionValue, ProductOption } from '@/types';
+
+interface ProductOptionsProps {
+  options: ProductOption[];
+  handleOptionChange: (optionName: string, selectedValue: OptionValue) => void;
+}
+
+const ProductOptions = ({
+  options,
+  handleOptionChange,
+}: ProductOptionsProps) => {
+  const formatDropdownOptions = (option: ProductOption) => {
+    return option.values.map(value => ({
+      value: value.name,
+      label: value.additionalPrice
+        ? `${value.name} (+${value.additionalPrice.toLocaleString()}원)`
+        : value.name,
+      additionalPrice: value.additionalPrice || 0,
+    }));
+  };
+
+  return (
+    <article className="gap-lg pb-lg md:py-xl flex flex-col">
+      {options &&
+        options.map((option, index) => (
+          <div key={index} className="gap-md flex items-center">
+            <label className="font-style-subHeading text-text-secondary min-w-[100px]">
+              {option.name}
+            </label>
+            <Dropdown
+              options={formatDropdownOptions(option)}
+              placeholder={`${option.name} 선택`}
+              onChange={selectedOption => {
+                const selectedValue = option.values.find(
+                  v => v.name === selectedOption.value,
+                );
+                if (selectedValue) {
+                  handleOptionChange(option.name, selectedValue);
+                }
+              }}
+            />
+          </div>
+        ))}
+    </article>
+  );
+};
+
+export default ProductOptions;

--- a/src/components/products/product-detail/ProductPrice.tsx
+++ b/src/components/products/product-detail/ProductPrice.tsx
@@ -1,0 +1,37 @@
+interface ProductPriceProps {
+  originalPrice: number;
+  finalPrice: number;
+  quantity: number;
+  discountRate: string;
+}
+
+const ProductPrice = ({
+  originalPrice,
+  finalPrice,
+  quantity,
+  discountRate,
+}: ProductPriceProps) => {
+  return (
+    <article className="pb-md md:pb-lg">
+      {originalPrice !== finalPrice ? (
+        <>
+          <p className="text-text-tertiaryInfo font-style-heading line-through">
+            {originalPrice.toLocaleString()}
+          </p>
+          <div className="mt-2xs flex items-center gap-2">
+            <p className="text-text-danger font-style-title">{discountRate}</p>
+            <p className="text-text-primary font-style-title">
+              {(finalPrice * quantity).toLocaleString()}원
+            </p>
+          </div>
+        </>
+      ) : (
+        <p className="text-text-primary font-style-title">
+          {(finalPrice * quantity).toLocaleString()}원
+        </p>
+      )}
+    </article>
+  );
+};
+
+export default ProductPrice;

--- a/src/components/products/product-detail/ProductQuantity.tsx
+++ b/src/components/products/product-detail/ProductQuantity.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { IconButton, Switch } from '@/components';
+
+interface ProductQuantityProps {
+  quantity: number;
+  maxPurchaseQuantity: number;
+  handleIncrease: () => void;
+  handleDecrease: () => void;
+}
+
+const ProductQuantity = ({
+  quantity,
+  maxPurchaseQuantity,
+  handleIncrease,
+  handleDecrease,
+}: ProductQuantityProps) => {
+  return (
+    <article className="pb-lg">
+      <div className="gap-md flex flex-col md:flex-row md:items-center md:justify-between md:gap-0">
+        <div className="gap-md flex items-center md:flex-col md:items-start md:gap-0">
+          <div className="gap-lg flex items-center">
+            <p className="font-style-heading text-text-secondary">수량</p>
+
+            <div className="gap-sm md:gap-lg flex items-center">
+              <IconButton
+                icon="minus"
+                iconProps={{ width: 18, height: 18 }}
+                variant={quantity <= 1 ? 'disabled' : undefined}
+                onClick={handleDecrease}
+              />
+              <span className="font-style-heading text-text-primary">
+                {quantity}
+              </span>
+              <IconButton
+                icon="plus"
+                iconProps={{ width: 18, height: 18 }}
+                variant={
+                  quantity >= maxPurchaseQuantity ? 'disabled' : undefined
+                }
+                onClick={handleIncrease}
+              />
+            </div>
+          </div>
+
+          <p className="font-style-paragraph text-text-tertiary">
+            고객 당 최대 {maxPurchaseQuantity}개 구매가능
+          </p>
+        </div>
+
+        <div className="gap-sm flex items-center">
+          <p className="font-style-subHeading text-text-secondary">
+            이 상품 재입고알림
+          </p>
+          <Switch />
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default ProductQuantity;

--- a/src/lib/msw/handlers/index.ts
+++ b/src/lib/msw/handlers/index.ts
@@ -2,10 +2,12 @@ import { userHandlers } from './userHandlers';
 import {
   productsHandlers,
   recommendedProductsHandlers,
+  productDetailHandlers,
 } from './productsHandlers';
 
 export const handlers = [
   ...userHandlers,
   ...productsHandlers,
   ...recommendedProductsHandlers,
+  ...productDetailHandlers,
 ];

--- a/src/lib/msw/handlers/productsHandlers.ts
+++ b/src/lib/msw/handlers/productsHandlers.ts
@@ -14,3 +14,24 @@ export const recommendedProductsHandlers = [
     return HttpResponse.json(products);
   }),
 ];
+
+export const productDetailHandlers = [
+  http.get(PRODUCTS_ENDPOINTS.DETAIL, ({ params }) => {
+    const { productId } = params;
+    let product;
+    products.forEach(p => {
+      const foundProduct = p.latestList.find(
+        item => item.productId.toString() === productId,
+      );
+      if (foundProduct) {
+        product = foundProduct;
+      }
+    });
+
+    if (!product) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    return HttpResponse.json(product);
+  }),
+];

--- a/src/mocks/products.ts
+++ b/src/mocks/products.ts
@@ -18,6 +18,27 @@ const products = [
         updatedAt: null,
         freeDelivery: true,
         almostOutOfStock: true,
+        options: [
+          {
+            name: '색상',
+            values: [
+              { name: '용달블루', additionalPrice: 0 },
+              {
+                name: '스페이스그레이',
+                additionalPrice: 500,
+              },
+            ],
+          },
+          {
+            name: '사이즈',
+            values: [
+              { name: 'S', additionalPrice: 0 },
+              { name: 'M', additionalPrice: 100 },
+              { name: 'L', additionalPrice: 200 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 5,
       },
       {
         productId: 2,
@@ -34,6 +55,16 @@ const products = [
         updatedAt: '2025-03-05 11:20:33',
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '색상',
+            values: [
+              { name: '미스틱 블랙', additionalPrice: 0 },
+              { name: '미스틱 실버', additionalPrice: 50000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 3,
@@ -50,6 +81,26 @@ const products = [
         updatedAt: null,
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '렌즈 키트',
+            values: [
+              { name: '바디 온리', additionalPrice: 0 },
+              {
+                name: 'RF 24-105mm F4-7.1 IS STM 키트',
+                additionalPrice: 450000,
+              },
+            ],
+          },
+          {
+            name: '추가 옵션',
+            values: [
+              { name: '추가 배터리', additionalPrice: 120000 },
+              { name: '삼각대', additionalPrice: 150000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 4,
@@ -66,6 +117,16 @@ const products = [
         updatedAt: '2025-03-06 14:22:18',
         freeDelivery: true,
         almostOutOfStock: true,
+        options: [
+          {
+            name: '모델',
+            values: [
+              { name: '에어팟 프로 2세대', additionalPrice: 0 },
+              { name: '에어팟 프로 맥스', additionalPrice: 350000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 5,
@@ -82,6 +143,8 @@ const products = [
         updatedAt: null,
         freeDelivery: false,
         almostOutOfStock: false,
+        options: [],
+        maxPurchaseQuantity: 5,
       },
       {
         productId: 6,
@@ -98,6 +161,24 @@ const products = [
         updatedAt: '2025-03-07 09:15:45',
         freeDelivery: true,
         almostOutOfStock: true,
+        options: [
+          {
+            name: '에디션',
+            values: [
+              { name: '디지털 에디션', additionalPrice: 0 },
+              { name: '디스크 드라이브 에디션', additionalPrice: 100000 },
+            ],
+          },
+          {
+            name: '번들',
+            values: [
+              { name: '본품만', additionalPrice: 0 },
+              { name: '추가 컨트롤러 포함', additionalPrice: 75000 },
+              { name: '게임 3종 포함', additionalPrice: 150000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 7,
@@ -114,6 +195,23 @@ const products = [
         updatedAt: '2025-03-02 11:25:10',
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '저장공간',
+            values: [
+              { name: '512GB', additionalPrice: 0 },
+              { name: '1TB', additionalPrice: 200000 },
+            ],
+          },
+          {
+            name: '메모리',
+            values: [
+              { name: '16GB', additionalPrice: 0 },
+              { name: '32GB', additionalPrice: 300000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 5,
       },
       {
         productId: 8,
@@ -130,6 +228,8 @@ const products = [
         updatedAt: '2025-03-01 10:35:20',
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 9,
@@ -146,6 +246,16 @@ const products = [
         updatedAt: '2025-03-05 14:20:15',
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '용량',
+            values: [
+              { name: '5.5L', additionalPrice: 0 },
+              { name: '7.2L', additionalPrice: 30000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 10,
@@ -162,6 +272,13 @@ const products = [
         updatedAt: '2025-03-08 15:30:25',
         freeDelivery: true,
         almostOutOfStock: true,
+        options: [
+          {
+            name: '컬러',
+            values: [{ name: '화이트', additionalPrice: 0 }],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 11,
@@ -178,6 +295,27 @@ const products = [
         updatedAt: '2025-03-09 09:45:15',
         freeDelivery: false,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '사이즈',
+            values: [
+              { name: '250mm', additionalPrice: 0 },
+              { name: '255mm', additionalPrice: 0 },
+              { name: '260mm', additionalPrice: 0 },
+              { name: '265mm', additionalPrice: 0 },
+              { name: '270mm', additionalPrice: 0 },
+            ],
+          },
+          {
+            name: '컬러',
+            values: [
+              { name: '블랙/화이트', additionalPrice: 0 },
+              { name: '그레이/블루', additionalPrice: 5000 },
+              { name: '레드/블랙', additionalPrice: 10000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
       {
         productId: 12,
@@ -194,6 +332,24 @@ const products = [
         updatedAt: '2025-03-06 16:40:20',
         freeDelivery: true,
         almostOutOfStock: false,
+        options: [
+          {
+            name: '구성',
+            values: [
+              { name: '바디 온리', additionalPrice: 0 },
+              { name: '28-70mm 렌즈 키트', additionalPrice: 500000 },
+            ],
+          },
+          {
+            name: '보증기간',
+            values: [
+              { name: '1년', additionalPrice: 0 },
+              { name: '2년', additionalPrice: 150000 },
+              { name: '3년', additionalPrice: 250000 },
+            ],
+          },
+        ],
+        maxPurchaseQuantity: 3,
       },
     ],
   },

--- a/src/services/fetchProducts.ts
+++ b/src/services/fetchProducts.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from '@/lib/axios';
 import { PRODUCT_PATHS } from '@/constants';
+import { Product } from '@/types';
 
 export const fetchProducts = async () => {
   const response = await axiosInstance.get(PRODUCT_PATHS.LIST);
@@ -9,6 +10,13 @@ export const fetchProducts = async () => {
 
 export const fetchRecommededProducts = async () => {
   const response = await axiosInstance.get(PRODUCT_PATHS.RECOMMEND);
+
+  return response.data;
+};
+
+export const fetchProductById = async (productId: string): Promise<Product> => {
+  const endpoint = PRODUCT_PATHS.DETAIL.replace(':productId', productId);
+  const response = await axiosInstance.get(endpoint);
 
   return response.data;
 };

--- a/src/stories/product/ProductDetailItem.stories.tsx
+++ b/src/stories/product/ProductDetailItem.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ProductDetailItem } from '@/components';
+
+const sampleImage =
+  'https://img.freepik.com/premium-vector/birthday-cake-illustration_190703-2.jpg?semt=ais_hybrid';
+
+const meta: Meta<typeof ProductDetailItem> = {
+  title: 'Product/ProductDetailItem',
+  component: ProductDetailItem,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="max-w-7xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ProductDetailItem>;
+
+export const Default: Story = {
+  args: {
+    titleUrl: sampleImage,
+    name: '맛있는 초콜릿 케이크 (특별한 생일 선물용)',
+    storeName: '뚜띠케이크',
+    freeDelivery: true,
+    almostOutOfStock: false,
+    likes: 128,
+    originalPrice: 38000,
+    sellingPrice: 28500,
+    maxPurchaseQuantity: 5,
+    options: [
+      {
+        name: '크기',
+        values: [
+          { name: '1호 (15cm)', additionalPrice: 0 },
+          { name: '2호 (18cm)', additionalPrice: 5000 },
+          { name: '3호 (21cm)', additionalPrice: 10000 },
+        ],
+      },
+      {
+        name: '맛',
+        values: [
+          { name: '초콜릿', additionalPrice: 0 },
+          { name: '바닐라', additionalPrice: 0 },
+          { name: '딸기', additionalPrice: 2000 },
+        ],
+      },
+      {
+        name: '메시지 카드',
+        values: [
+          { name: '미포함', additionalPrice: 0 },
+          { name: '생일 축하 메시지 (+3,000원)', additionalPrice: 3000 },
+          { name: '기념일 축하 메시지 (+3,000원)', additionalPrice: 3000 },
+        ],
+      },
+    ],
+  },
+};
+
+export const NoOptions: Story = {
+  args: {
+    ...Default.args,
+    options: [],
+  },
+};
+
+export const LimitedQuantity: Story = {
+  args: {
+    ...Default.args,
+    maxPurchaseQuantity: 2,
+  },
+};

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 40%;
   transform: translateY(-50%);
-  z-index: 10;
+  z-index: 1;
   border: 1px solid var(--color-border-primary);
   width: 40px;
   height: 40px;

--- a/src/types/productType.ts
+++ b/src/types/productType.ts
@@ -1,5 +1,15 @@
 import { StaticImageData } from 'next/image';
 
+export interface OptionValue {
+  name: string;
+  additionalPrice?: number;
+}
+
+export interface ProductOption {
+  name: string;
+  values: OptionValue[];
+}
+
 export interface Product {
   productId: number;
   storeName: string;
@@ -14,4 +24,6 @@ export interface Product {
   updatedAt?: Date;
   freeDelivery?: boolean;
   almostOutOfStock?: boolean;
+  options: ProductOption[];
+  maxPurchaseQuantity: number;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품 상세 페이지 상단에 있는 주요 내용을 담당하는 컴포넌트를 제작했어요.

## 🔧 변경 사항

### 이전 PR에서 지나친 것

- 이전 PR 사항에서 `Dropdown` 컴포넌트에 디자인을 수정했어요.
- `RadioIcon`에서 fill 색상을 토큰에 정의된 색상으로 수정했어요.
- `Dropdown` 컴포넌트에서 라벨이 두 줄 이상일 경우 오버플로우 처리했어요.

### 이번 PR

- 목데이터에 상품에 대한 옵션 정보와 최대 구매 수량을 추가했어요.
- `Product` 타입에 `옵션`과 `최대 구매 수량`을 추가했어요.
- 핸들러와 서비스함수를 임의로 만들어 테스트했어요.
- 추천 상품 캐러셀에서의 arrow 버튼과 플로팅 버튼의 `z-index`를 수정/추가 했어요.
- 상품 상세에 대한 아이템을 제작하고 스토리북을 작성했어요.

## 📸 스크린샷

스토리북을 통해 확인 바랍니다!

## ❌  오류

![image](https://github.com/user-attachments/assets/59496da4-0540-4bcd-b8ef-f6963141417f)

위처럼 `pre-commit`시에 오류가 발생했어요. 

```yaml
pre-commit:
  parallel: true
  commands:
    debug:
      run: echo "Running pre-commit hooks"
    eslint:
      glob: '**/*.{js,ts,jsx,tsx}'
      run: pnpm exec eslint "{staged_files}" --fix && echo "ESLint ran on {staged_files}"
      stage_fixed: true
    prettier:
      glob: '**/*.{js,ts,jsx,tsx,json,yaml,md,css}'
      run: pnpm exec prettier --write "{staged_files}"
      stage_fixed: true
commit-msg:
  commands:
    lint-commit-msg:
      run: pnpm exec commitlint --edit {1}
```
여기서 각 `{staged_files}`에 따옴표를 붙여주니 해결이 됐어요.

`{staged_files}` 변수를 따옴표로 감싸면 파일 경로에 있는 특수 문자(`(`, `)`, `[`, `]` 등)이 쉘에 의해 특별한 의미로 해석되지 않고 문자 그대로 처리돼요!
이 방식을 사용하면 특수 문자가 포함된 파일 경로도 처리할 수 있어요.