### PR TITLE
[🐞 hotfix] 같은 레벨의 경로에 있는 파일을 최상위 경로에서 import하니 스토리북 에러 발생

### DIFF
--- a/src/schemas/auth/resetPwSchema.ts
+++ b/src/schemas/auth/resetPwSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { AUTH_CONSTANTS } from '@/constants';
-import { authSchema } from '@/schemas/auth/authSchema';
+import { authSchema } from './authSchema';
 
 const { CHECK_PW_INPUT } = AUTH_CONSTANTS;
 

--- a/src/schemas/auth/signinSchema.ts
+++ b/src/schemas/auth/signinSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { AUTH_CONSTANTS } from '@/constants';
-import { authSchema } from '@/schemas/auth/authSchema';
+import { authSchema } from './authSchema';
 
 const { PW_INPUT } = AUTH_CONSTANTS;
 

--- a/src/schemas/auth/signupSchema.ts
+++ b/src/schemas/auth/signupSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { AUTH_CONSTANTS } from '@/constants';
-import { authSchema } from '@/schemas/auth/authSchema';
+import { authSchema } from './authSchema';
 
 const { CHECK_PW_INPUT } = AUTH_CONSTANTS;
 

--- a/src/schemas/auth/verifyEmailSchema.ts
+++ b/src/schemas/auth/verifyEmailSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { authSchema } from '@/schemas/auth/authSchema';
+import { authSchema } from './authSchema';
 
 export const verifyEmailSchema = z.object({
   email: authSchema.shape.email,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

같은 레벨의 경로에 있는 파일을 최상위 경로에서 import하니 스토리북에서 에러가 발생하는 이슈 해결


## 🔧 변경 사항

- `import { authSchema } from '@/schemas'`  =>  `import { authSchema } from '@/schemas/auth/authSchema'`

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
