### PR TITLE
[✨ feat] JWT 관리 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "react-slick": "^0.30.3",
+    "server-only": "^0.0.1",
     "slick-carousel": "^1.8.1",
     "tailwind-merge": "^3.0.2",
     "zod": "^3.24.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-slick:
         specifier: ^0.30.3
         version: 0.30.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
@@ -4113,6 +4116,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -9160,6 +9166,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/src/lib/axios/index.ts
+++ b/src/lib/axios/index.ts
@@ -5,6 +5,7 @@ import {
   SERVER_API_BASE_URL,
   SERVER_API_VERSION_V1,
 } from '@/constants';
+import { getAccessToken, refreshAccessToken, removeTokens } from '@/services';
 
 const isServer = typeof window === 'undefined';
 
@@ -19,3 +20,40 @@ export const axiosInstance = axios.create({
   },
   timeout: 10000,
 });
+
+if (isServer) {
+  axiosInstance.interceptors.request.use(
+    async config => {
+      const accessToken = await getAccessToken();
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return config;
+    },
+
+    error => Promise.reject(error),
+  );
+
+  axiosInstance.interceptors.response.use(
+    response => response,
+    async error => {
+      if (error.response?.status === 401 && !error.config._retry) {
+        error.config._retry = true;
+
+        try {
+          const newAccessToken = await refreshAccessToken();
+
+          error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+
+          return axiosInstance(error.config);
+        } catch (refreshError) {
+          removeTokens();
+          return Promise.reject(refreshError);
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}

--- a/src/lib/axios/index.ts
+++ b/src/lib/axios/index.ts
@@ -5,7 +5,7 @@ import {
   SERVER_API_BASE_URL,
   SERVER_API_VERSION_V1,
 } from '@/constants';
-import { getAccessToken, refreshAccessToken, removeTokens } from '@/services';
+import { getAccessToken, renewAccessToken, removeTokens } from '@/services';
 
 const isServer = typeof window === 'undefined';
 
@@ -42,7 +42,7 @@ if (isServer) {
         error.config._retry = true;
 
         try {
-          const newAccessToken = await refreshAccessToken();
+          const newAccessToken = await renewAccessToken();
 
           error.config.headers.Authorization = `Bearer ${newAccessToken}`;
 

--- a/src/mocks/auth.ts
+++ b/src/mocks/auth.ts
@@ -31,8 +31,8 @@ export const AUTH_REQUEST = {
   },
   SIGNIN_EMAIL: {
     SUCCESS: {
-      access_token: '',
-      refresh_token: '',
+      access_token: 'temp-access-token',
+      refresh_token: 'temp-refresh-token',
     },
     ERROR: {
       error: '이메일 혹은 비밀번호를 다시 확인해주세요.',

--- a/src/server-actions/auth/signinAction.ts
+++ b/src/server-actions/auth/signinAction.ts
@@ -2,6 +2,7 @@
 
 import { signinSchema } from '@/schemas';
 import { signin } from '@/services';
+import { setAccessTokens, setRefreshTokens } from '@/services/tokenService';
 import type { EmailVerificationState } from '@/types';
 
 export const signinAction = async (
@@ -38,7 +39,13 @@ export const signinAction = async (
       };
     }
 
-    await signin(validatedData.data?.email || '', validatedData.data?.pw || '');
+    const response = await signin(
+      validatedData.data?.email || '',
+      validatedData.data?.pw || '',
+    );
+
+    await setAccessTokens(response.access_token);
+    await setRefreshTokens(response.refresh_token);
 
     return {
       ...prevState,

--- a/src/server-actions/auth/signinAction.ts
+++ b/src/server-actions/auth/signinAction.ts
@@ -2,7 +2,7 @@
 
 import { signinSchema } from '@/schemas';
 import { signin } from '@/services';
-import { setAccessTokens, setRefreshTokens } from '@/services/tokenService';
+import { setAccessToken, setRefreshToken } from '@/services/tokenService';
 import type { EmailVerificationState } from '@/types';
 
 export const signinAction = async (
@@ -44,8 +44,8 @@ export const signinAction = async (
       validatedData.data?.pw || '',
     );
 
-    await setAccessTokens(response.access_token);
-    await setRefreshTokens(response.refresh_token);
+    await setAccessToken(response.access_token);
+    await setRefreshToken(response.refresh_token);
 
     return {
       ...prevState,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,3 @@
 export * from './fetchProducts';
 export * from './authService';
-// export * from './tokenService';
+export * from './tokenService';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchProducts';
 export * from './authService';
+// export * from './tokenService';

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,3 +1,6 @@
+'use server';
+// import 'server-only';
+
 import { cookies } from 'next/headers';
 
 import { axiosInstance } from '@/lib';

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,0 +1,65 @@
+import { cookies } from 'next/headers';
+
+import { axiosInstance } from '@/lib';
+
+export const getAccessTokens = async () => {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
+  if (!accessToken) return null;
+
+  return accessToken;
+};
+
+export const getRefreshTokens = async () => {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refresh_token')?.value;
+
+  if (!refreshToken) return null;
+
+  return refreshToken;
+};
+
+export const setAccessTokens = async (accessToken: string) => {
+  const cookieStore = await cookies();
+
+  cookieStore.set('access_token', accessToken, {
+    httpOnly: true,
+    // secure: true, // 📌 https 프로토콜 통신일 경우에만 가능하도록 강제하는 옵션이므로 배포 환경에서 테스트할 때 사용하기
+    maxAge: 60 * 60,
+    path: '/',
+  });
+};
+
+export const setRefreshTokens = async (refreshToken: string) => {
+  const cookieStore = await cookies();
+
+  cookieStore.set('refresh_token', refreshToken, {
+    httpOnly: true,
+    // secure: true, // 📌 https 프로토콜 통신일 경우에만 가능하도록 강제하는 옵션이므로 배포 환경에서 테스트할 때 사용하기
+    maxAge: 7 * 24 * 60 * 60,
+    path: '/',
+  });
+};
+
+export const refreshAccessToken = async () => {
+  try {
+    const refreshToken = getRefreshTokens();
+    const { data } = await axiosInstance.post('/members/temp-endpoint', {
+      refresh_token: refreshToken,
+    });
+    const { access_token: accessToken } = data;
+
+    await setAccessTokens(accessToken);
+  } catch (error) {
+    console.error(error);
+    await removeTokens();
+  }
+};
+
+export const removeTokens = async () => {
+  const cookieStore = await cookies();
+
+  cookieStore.delete('access_token');
+  cookieStore.delete('refresh_token');
+};

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -45,7 +45,7 @@ export const setRefreshToken = async (refreshToken: string) => {
   });
 };
 
-export const refreshAccessToken = async () => {
+export const renewAccessToken = async () => {
   try {
     const refreshToken = getRefreshToken();
     const { data } = await axiosInstance.post('/members/temp-endpoint', {

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 
 import { axiosInstance } from '@/lib';
 
-export const getAccessTokens = async () => {
+export const getAccessToken = async () => {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('access_token')?.value;
 
@@ -11,7 +11,7 @@ export const getAccessTokens = async () => {
   return accessToken;
 };
 
-export const getRefreshTokens = async () => {
+export const getRefreshToken = async () => {
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get('refresh_token')?.value;
 
@@ -20,7 +20,7 @@ export const getRefreshTokens = async () => {
   return refreshToken;
 };
 
-export const setAccessTokens = async (accessToken: string) => {
+export const setAccessToken = async (accessToken: string) => {
   const cookieStore = await cookies();
 
   cookieStore.set('access_token', accessToken, {
@@ -31,7 +31,7 @@ export const setAccessTokens = async (accessToken: string) => {
   });
 };
 
-export const setRefreshTokens = async (refreshToken: string) => {
+export const setRefreshToken = async (refreshToken: string) => {
   const cookieStore = await cookies();
 
   cookieStore.set('refresh_token', refreshToken, {
@@ -44,13 +44,13 @@ export const setRefreshTokens = async (refreshToken: string) => {
 
 export const refreshAccessToken = async () => {
   try {
-    const refreshToken = getRefreshTokens();
+    const refreshToken = getRefreshToken();
     const { data } = await axiosInstance.post('/members/temp-endpoint', {
       refresh_token: refreshToken,
     });
     const { access_token: accessToken } = data;
 
-    await setAccessTokens(accessToken);
+    await setAccessToken(accessToken);
   } catch (error) {
     console.error(error);
     await removeTokens();

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,5 +1,5 @@
 'use server';
-// import 'server-only';
+import 'server-only';
 
 import { cookies } from 'next/headers';
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- msw의 임시 로그인 api를 이용해서 로그인 성공 시 반환받은 access_token, refresh_token이 쿠키에 저장되도록 했어요
- axios interceptor를 이용해서 access_token이 있는 경우 모든 api 요청의 header에 Authorization을 실어주도록 했어요
- axios interceptor를 이용해서 access_token 만료 이후의 api 요청 시 refresh_token으로 access_token이 갱신되도록 했어요

## 🔧 변경 사항

- 주요 변경 사항을 요약해 주세요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

서버 사이드 api 요청의 경우에만 interceptor가 요청을 가로채요! 정상적인 의도로 동작되도록 하기 위해서 반드시 클라이언트 사이드에서의 직접적인 api 호출은 하지말아주세요!

