### PR TITLE
[🐞 hotfix] 클라이언트 환경에서 실행되는 스토리북에 서버 로직이 포함되지 않도록 변경

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,6 +18,15 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: ['public'],
+  webpackFinal: async config => {
+    process.env.STORYBOOK = 'true';
+    config.module?.rules?.push({
+      test: /src\/services\/tokenService\.ts$/,
+      use: 'null-loader',
+    });
+
+    return config;
+  },
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-storybook": "^0.11.3",
     "lefthook": "^1.11.2",
     "msw": "^2.7.3",
+    "null-loader": "^4.0.1",
     "postcss": "^8",
     "prettier": "^3.5.2",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       msw:
         specifier: ^2.7.3
         version: 2.7.3(@types/node@20.17.19)(typescript@5.7.3)
+      null-loader:
+        specifier: ^4.0.1
+        version: 4.0.1(webpack@5.98.0(esbuild@0.25.0))
       postcss:
         specifier: ^8
         version: 8.5.3
@@ -3537,6 +3540,12 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  null-loader@4.0.1:
+    resolution: {integrity: sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8603,6 +8612,12 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  null-loader@4.0.1(webpack@5.98.0(esbuild@0.25.0)):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.98.0(esbuild@0.25.0)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## ❌  에러 내용

<img width="682" alt="Image" src="https://github.com/user-attachments/assets/283f0283-8b9a-465a-939b-9d2405d097a8" />
클라이언트 환경에서 실행되는 스토리북에 서버 로직이 포함되어있어 에러가 발생해요

## 📋 작업 내용
- `null-loader` 설치
- webpack 설정을 수정하여 서버 로직이 존재하는 파일(`tokenService`)을 `null-loader`로 대체

## 🔧 변경 사항

- 스토리북 실행시에만 서버 로직이 존재하는 파일(`tokenService`)을 `null-loader`로 대체하도록 webpack 설정을 수정했어요
