### PR TITLE
[🔧 fix] 유틸 함수 getDehydratedState의 파리미터 queryOptions 타입이슈 해결과 유연성 확장

### DIFF
--- a/src/app/(root)/page.tsx
+++ b/src/app/(root)/page.tsx
@@ -15,6 +15,9 @@ const HomePage = () => {
       <Suspense fallback={<ProductListSkeleton />}>
         <ProductList />
       </Suspense>
+
+      {/** 📍 hydration과 클라이언트 컴포넌트 예시  */}
+      <ProductListWrapTemp />
     </>
   );
 };

--- a/src/queries/productsQueries.ts
+++ b/src/queries/productsQueries.ts
@@ -1,7 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 
 import { QUERY_KEYS_ENDPOINT, PRODUCTS_QUERY_KEY } from '@/constants';
-import type { Product } from '@/types';
 import {
   fetchProducts,
   fetchRecommededProducts,
@@ -10,28 +9,16 @@ import {
 
 export const productsQueryOptions = queryOptions({
   queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.LIST],
-  queryFn: async () => {
-    const res = await fetchProducts();
-
-    return res;
-  },
+  queryFn: async () => await fetchProducts(),
 });
 
 export const recommededProductsQueryOptions = queryOptions({
   queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.RECOMMEND],
-  queryFn: async () => {
-    const res = await fetchRecommededProducts();
-
-    return res;
-  },
+  queryFn: async () => await fetchRecommededProducts(),
 });
 
 export const productByIdQueryOptions = (productId: string) =>
   queryOptions({
     queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, productId],
-    queryFn: async () => {
-      const res: Product = await fetchProductById(productId);
-
-      return res;
-    },
+    queryFn: async () => await fetchProductById(productId),
   });

--- a/src/utils/hydration.ts
+++ b/src/utils/hydration.ts
@@ -1,14 +1,24 @@
 import { dehydrate } from '@tanstack/react-query';
+import { QueryKey, DehydratedState } from '@tanstack/query-core';
+import { QueryObserverOptions } from '@tanstack/react-query';
 
 import { getQueryClient } from '@/lib/tanstack';
-import type { QueryKey, QueryFunction } from '@tanstack/query-core';
 
-export const getDehydratedState = async (queryOptions: {
-  queryKey: QueryKey;
-  queryFn: QueryFunction;
-  staleTime?: number;
-  gcTime?: number;
-}) => {
+export const getDehydratedState = async <
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  // QueryOptions 인터페이스를 사용하여 TanStack Query의 타입 정의를 따름
+  queryOptions: QueryObserverOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
+  >,
+): Promise<DehydratedState> => {
   const queryClient = getQueryClient();
 
   // 서버에서 데이터 미리 가져오기


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- hydration 을 진행하고 dehydration한 데이터 값을 반환하는 유틸 함수 `getDehydratedState`의 인자 쿼리옵션 타입 에러를 해결했어요
- 현재 타입 에러 외에도 고정된 쿼리 옵션의 타입 지정으로 쿼리옵션을 추가할 경우 유틸함수의 타입을 계속 수정해야하는 불편함이 있으므로 tanstack query에서 정의하는 `queryOptions()` 메서드가 반환하는 타입으로 지정했어요.

- 자세한 타입 에러 내용은 #137 이슈에서 확인해주세요!

## 🔧 변경 사항

- `getDehydratedState` 함수의 파라미터 queryOptions의 타입을 tanstack query에서 정의하는  QueryOptions 인터페이스와 제너릭을 활용했어요.

  ```typescript
  import { dehydrate } from '@tanstack/react-query';
  import { QueryKey, DehydratedState } from '@tanstack/query-core';
  import { QueryObserverOptions } from '@tanstack/react-query';
  
  import { getQueryClient } from '@/lib/tanstack';
  
  export const getDehydratedState = async <
    TQueryFnData = unknown,
    TError = Error,
    TData = TQueryFnData,
    TQueryKey extends QueryKey = QueryKey,
  >(
    // QueryOptions 인터페이스를 사용하여 TanStack Query의 타입 정의를 따름
    queryOptions: QueryObserverOptions<
      TQueryFnData,
      TError,
      TData,
      TQueryFnData,
      TQueryKey
    >,
  ): Promise<DehydratedState> => {
    const queryClient = getQueryClient();
  
    // 서버에서 데이터 미리 가져오기
    await queryClient.prefetchQuery(queryOptions);
  
    // 데이터를 dehydrate하여 클라이언트로 전달
    const dehydratedState = dehydrate(queryClient);
  
    return dehydratedState;
  };
  ``` 

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

**현재 쿼리키와 쿼리함수를 제외한 쿼리 옵션은 인스턴스에서 defaultOptions으로 정의하고 있어요**

```typescript
import { cache } from 'react';
import { QueryClient } from '@tanstack/react-query';

export const getQueryClient = cache(
  () =>
    new QueryClient({
      defaultOptions: {
        queries: {
          staleTime: 1000 * 60 * 5, // 5분
          refetchOnMount: 'always',
          refetchOnWindowFocus: false,
          refetchOnReconnect: false,
        },
      },
    }),
);
``` 

**유틸함수를 사용해도 타입에러 없이 쿼리 옵션을 자유롭게 추가할 수 있어요.** 

- 예시 1 : 쿼리 정의할 때 추가

  ```typescript
  // queries/productsQueries.ts
  
  export const productsQueryOptions = queryOptions({
    queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.LIST],
    queryFn: async () => await fetchProducts(),
  });

  export const recommededProductsQueryOptions = queryOptions({
    queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.RECOMMEND],
    queryFn: async () => await fetchRecommededProducts(),
  });
  
  export const productByIdQueryOptions = (productId: string) =>
    queryOptions({
      queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, productId],
      queryFn: async () => await fetchProductById(productId),
      staleTime: 1000 * 60 * 10, // 10분
      retry: 3,
      retryDelay: 1000,
    });
  ``` 

- 예시 2 : 데이터를 요청하는 시점에서 추가

  ```typescript
  import { Suspense } from 'react';
  import { HydrationBoundary } from '@tanstack/react-query';
  
  import { productsQueryOptions } from '@/queries';
  import { getDehydratedState } from '@/utils';
  import { ProductListSkeleton } from '@/components';
  import ProductListClientTemp from './ProductListClientTemp';
  
  const ProductListWrapTemp = async () => {
    const dehydratedState = await getDehydratedState({
      ...productsQueryOptions,
      staleTime: 1000 * 60 * 10, // 10분
      retry: 3,
      retryDelay: 1000,
    });
  
    return (
      <HydrationBoundary state={dehydratedState}>
        <Suspense fallback={<ProductListSkeleton />}>
          <ProductListClientTemp />
        </Suspense>
      </HydrationBoundary>
    );
  };
  
  export default ProductListWrapTemp;
  ``` 