### PR TITLE
[✨ feat] orders와 payments의 API Schema, 타입 정의

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,5 @@ export * from './iconType';
 export * from './productType';
 export * from './authType';
 export * from './cartType';
+export * from './ordersType';
+export * from './paymentsType';

--- a/src/types/ordersType.ts
+++ b/src/types/ordersType.ts
@@ -54,7 +54,7 @@ export interface OrderDetailResponseAPISchema {
 }
 
 // 주문내역 조회 API 스키마
-export interface OrderListResponseAPISchema {
+export interface OrderHistoryListItem {
   orderId: number;
   orderNumber: string;
   orderName: string;
@@ -63,3 +63,5 @@ export interface OrderListResponseAPISchema {
   orderStatus: string;
   orderItems: OrderItem[];
 }
+
+export type OrderHistoryListResponseAPISchema = OrderHistoryListItem[];

--- a/src/types/ordersType.ts
+++ b/src/types/ordersType.ts
@@ -1,0 +1,65 @@
+import { PaymentType } from './paymentsType';
+
+export interface OrderProductItem {
+  productItemId: number;
+  quantity: number;
+}
+
+export interface OrderItem {
+  productItemId: number;
+  productName: string;
+  productImgUrl: string;
+  firstOptionName: string;
+  firstOptionValue: string;
+  secondOptionName: string;
+  secondOptionValue: string;
+  quantity: number;
+  price: number;
+}
+
+// 주문서 요청 API 스키마
+export interface OrderCheckoutRequestAPISchema {
+  orderItems: OrderProductItem[];
+}
+
+// 주문서 응답 API 스키마
+export interface OrderCheckoutResponseAPISchema {
+  totalDiscountAmount: number;
+  totalProductAmount: number;
+  deliveryFee: number;
+  totalAmount: number;
+  orderItems: OrderItem[];
+}
+
+// 주문내역 상세 조회 API 스키마
+export interface OrderDetailResponseAPISchema {
+  orderNumber: string;
+  orderStatus: string;
+  totalDiscountAmount: number;
+  totalProductAmount: number;
+  deliveryFee: number;
+  totalAmount: number;
+  paymentType: PaymentType;
+  orderedAt: string;
+  paidAt: string;
+  deliveredAt: string;
+  completedAt: string;
+  orderItems: OrderItem[];
+  recipientName: string;
+  recipientPhone: string;
+  recipientAddress: string;
+  zipCode: string;
+  note: string;
+  storeName: string;
+}
+
+// 주문내역 조회 API 스키마
+export interface OrderListResponseAPISchema {
+  orderId: number;
+  orderNumber: string;
+  orderName: string;
+  completedAt: string;
+  totalAmount: number;
+  orderStatus: string;
+  orderItems: OrderItem[];
+}

--- a/src/types/paymentsType.ts
+++ b/src/types/paymentsType.ts
@@ -1,0 +1,32 @@
+import { OrderProductItem } from './ordersType';
+
+// 결제 수단 타입
+export type PaymentType = 'CARD';
+
+// 주문/결제 요청 API 스키마
+export interface PaymentsRequestAPISchema {
+  totalDiscountAmount: number;
+  totalProductAmount: number;
+  deliveryFee: number;
+  totalAmount: number;
+  paymentType: PaymentType;
+  orderItems: OrderProductItem[];
+}
+
+// 결제 승인 API 스키마
+export interface PaymentsApproveRequestAPISchema {
+  paymentKey: string;
+  orderId: string;
+  amount: number;
+}
+
+// 결제 조회 API 스키마
+export interface PaymentsDetailResponseAPISchema {
+  paymentId: number;
+  orderName: string;
+  amount: number;
+  paymentStatus: string;
+  completedAt: string;
+  orderId: number;
+  paymentMethodName: string;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- orders와 payments의 API Schema, 타입 정의 ([swagger](https://tutti-server-web-hqbha7bpbxfhcsa8.koreacentral-01.azurewebsites.net/swagger-ui/index.html#/Orders/getOrderPage))
- 장바구니와 상품 상세 페이지 의 버튼에서도 사용

## 🔧 변경 사항

- ordersType.ts, paymentsType.ts 파일추가와 types/index.ts 파일 추가 

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

**변수명 정의**
-  `orderProductItems`: 주문/결제 페이지에서 결제하기 위한 상품에 대한 리스트
- `orderHistoryList`: 주문 내역 페이지에서 모든 주문 항목에 대한 정보를 보여주는 전체 리스트
- `orderItems`: 주문번호 기준으로 묶인 항목 리스트 

**참고**
백엔드의 경우 : 결제하기 위한 상품에 대한 리스트, 주문번호 기준으로 묶인 항목 리스트 두 경우 모두 `orderItems` 변수 사용
-  `orderItems`: 주문/결제 페이지에서 결제하기 위한 상품에 대한 리스트
- `orders`: 주문 내역 페이지에서 모든 주문 항목에 대한 정보를 보여주는 전체 리스트
- `orderItems`: 주문번호 기준으로 묶인 항목 리스트 