### PR TITLE
[✨ feat] 비회원/회원에 따른 장바구니 삭제 로직 추가 (#147)

### DIFF
--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { calculateDiscountRate } from '@/utils';
 import { useCartStore } from '@/stores';
 import type { CartProductItem } from '@/types';
+import { removeFromCart } from '@/services';
 import CartItemImage from './CartItemImage';
 import CartItemHeader from './CartItemHeader';
 import CartItemOptions from './CartItemOptions';
@@ -26,8 +27,13 @@ const CartItem = ({
   maxQuantity,
 }: CartProductItem) => {
   const [productQuantity, setProductQuantity] = useState<number>(quantity);
-  const { toggleItemCheckbox, updateQuantity, removeItem, checkedItems } =
-    useCartStore();
+  const {
+    items,
+    toggleItemCheckbox,
+    updateQuantity,
+    removeItem,
+    checkedItems,
+  } = useCartStore();
 
   const isChecked = checkedItems[productItemId] || false;
 
@@ -50,9 +56,16 @@ const CartItem = ({
     }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (window.confirm('해당 상품을 삭제하시겠습니까?')) {
-      removeItem(productItemId);
+      try {
+        await removeFromCart(items, [productItemId]);
+
+        removeItem(productItemId);
+      } catch (error) {
+        console.error('장바구니에서 상품을 삭제하는 데 실패했습니다.', error);
+        alert('상품 삭제에 실패했습니다. 다시 시도해주세요.');
+      }
     }
   };
 

--- a/src/components/products/product-detail/ProductPrice.tsx
+++ b/src/components/products/product-detail/ProductPrice.tsx
@@ -16,7 +16,7 @@ const ProductPrice = ({
       {originalPrice !== finalPrice ? (
         <>
           <p className="text-text-tertiaryInfo font-style-heading line-through">
-            {originalPrice.toLocaleString()}
+            {(originalPrice * quantity).toLocaleString()}
           </p>
           <div className="mt-2xs flex items-center gap-2">
             <p className="text-text-danger font-style-title">{discountRate}</p>

--- a/src/hooks/common/useCart.ts
+++ b/src/hooks/common/useCart.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 
 import { useCartStore } from '@/stores';
-import { fetchCart } from '@/services';
+import { fetchCart, removeFromCart } from '@/services';
 
 const useCart = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -11,6 +11,7 @@ const useCart = () => {
 
   const {
     items,
+    checkedItems,
     setCartItems,
     toggleAllCheckbox,
     removeSelectedItems,
@@ -37,10 +38,25 @@ const useCart = () => {
     loadData();
   }, [setCartItems]);
 
-  const handleDeleteSelected = () => {
+  const handleDeleteSelected = async () => {
     const checkedCount = getCheckedItemsCount();
-    if (checkedCount > 0 && window.confirm('선택한 상품을 삭제하시겠습니까?')) {
-      removeSelectedItems();
+    if (checkedCount === 0) return;
+
+    if (window.confirm('선택한 상품을 삭제하시겠습니까?')) {
+      try {
+        const selectedProductItemIds = Object.entries(checkedItems)
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .filter(([_, checked]) => checked)
+          .map(([productItemId]) => Number(productItemId));
+
+        await removeFromCart(items, selectedProductItemIds);
+
+        removeSelectedItems();
+      } catch (err) {
+        console.error('선택한 상품 삭제 중 오류가 발생했습니다.', err);
+        setError(err as Error);
+        alert('선택한 상품 삭제에 실패했습니다.');
+      }
     }
   };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

비회원/회원에 따라 장바구니 삭제 로직을 추가했어요.

## 🔧 변경 사항

- 비회원/회원에 따른 장바구니 삭제 서비스 함수를 만들고 적용했어요.
- 상품 상세 가격 정보에서 세일 전 가격을 수량이 오르고 내림에 따라 동시에 렌더링 되도록 했어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
