### PR TITLE
[✨ feat] 토스트 알림 유틸 함수 추가 (#149)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-slick": "^0.30.3",
     "server-only": "^0.0.1",
     "slick-carousel": "^1.8.1",
+    "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
+      sonner:
+        specifier: ^2.0.1
+        version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -4202,6 +4205,12 @@ packages:
     resolution: {integrity: sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==}
     peerDependencies:
       jquery: '>=1.8.0'
+
+  sonner@2.0.1:
+    resolution: {integrity: sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9307,6 +9316,11 @@ snapshots:
   slick-carousel@1.8.1(jquery@3.7.1):
     dependencies:
       jquery: 3.7.1
+
+  sonner@2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 
+import { Toaster } from 'sonner';
+
 import '@/styles/globals.css';
 
 const pretendard = localFont({
@@ -25,6 +27,7 @@ export default function RootLayout({
       <body
         className={`${pretendard.variable} font-pretendard font-style-paragraph flex min-h-screen flex-col items-center`}
       >
+        <Toaster position="bottom-right" />
         {children}
       </body>
     </html>

--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -6,6 +6,7 @@ import { calculateDiscountRate } from '@/utils';
 import { useCartStore } from '@/stores';
 import type { CartProductItem } from '@/types';
 import { removeFromCart } from '@/services';
+import { toast } from '@/utils';
 import CartItemImage from './CartItemImage';
 import CartItemHeader from './CartItemHeader';
 import CartItemOptions from './CartItemOptions';
@@ -59,12 +60,13 @@ const CartItem = ({
   const handleDelete = async () => {
     if (window.confirm('해당 상품을 삭제하시겠습니까?')) {
       try {
-        await removeFromCart(items, [productItemId]);
+        const result = await removeFromCart(items, [productItemId]);
 
         removeItem(productItemId);
+        toast.success(result.message);
       } catch (error) {
         console.error('장바구니에서 상품을 삭제하는 데 실패했습니다.', error);
-        alert('상품 삭제에 실패했습니다. 다시 시도해주세요.');
+        toast.error('장바구니에서 상품을 삭제하는 데 실패했습니다.');
       }
     }
   };

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/utils';
+import Icon from './Icon';
+
+type ToastType = 'success' | 'error';
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+}
+
+const SuccessIcon = () => <Icon iconName="check" />;
+const ErrorIcon = () => <Icon iconName="info" />;
+
+const Toast = ({ message, type = 'success' }: ToastProps) => {
+  const bgColorClass = {
+    success: 'bg-bg-primaryInteraction',
+    error: 'bg-bg-dangerInteraction',
+  }[type];
+
+  const Icon = {
+    success: SuccessIcon,
+    error: ErrorIcon,
+  }[type];
+
+  return (
+    <div
+      className={cn(
+        'font-pretendard gap-md px-lg py-md text-text-inverse flex items-center rounded-xl shadow-lg',
+        bgColorClass,
+      )}
+    >
+      <div className="flex-shrink-0">
+        <Icon />
+      </div>
+      <p className="font-style-paragraph flex-1">{message}</p>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -14,3 +14,4 @@ export { default as RadioOption } from './RadioOption';
 export { default as Switch } from './Switch';
 export { default as StepProgressBar } from './StepProgressBar';
 export { default as Checkbox } from './Checkbox';
+export { default as Toast } from './Toast';

--- a/src/components/products/product-detail/ProductActions.tsx
+++ b/src/components/products/product-detail/ProductActions.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components';
 import { addCart } from '@/services';
+import { toast } from '@/utils';
 
 interface ProductActionsProps {
   productId: number;
@@ -15,7 +16,18 @@ const ProductActions = ({
   disabled,
 }: ProductActionsProps) => {
   const handleCartClick = async () => {
-    await addCart(productId, productItemId, quantity);
+    try {
+      const result = await addCart(productId, productItemId, quantity);
+
+      if (result.success) {
+        toast.success(result.message || '장바구니에 추가되었습니다.');
+      } else {
+        toast.error(result.message || '장바구니에 추가하지 못했습니다.');
+      }
+    } catch (error) {
+      console.error('장바구니 담기 중 오류가 발생했습니다.', error);
+      toast.error('장바구니 담기에 실패했습니다.');
+    }
   };
 
   return (

--- a/src/hooks/common/useCart.ts
+++ b/src/hooks/common/useCart.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 
 import { useCartStore } from '@/stores';
 import { fetchCart, removeFromCart } from '@/services';
+import { toast } from '@/utils';
 
 const useCart = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -49,13 +50,14 @@ const useCart = () => {
           .filter(([_, checked]) => checked)
           .map(([productItemId]) => Number(productItemId));
 
-        await removeFromCart(items, selectedProductItemIds);
+        const result = await removeFromCart(items, selectedProductItemIds);
 
         removeSelectedItems();
+        toast.success(result.message);
       } catch (err) {
         console.error('선택한 상품 삭제 중 오류가 발생했습니다.', err);
         setError(err as Error);
-        alert('선택한 상품 삭제에 실패했습니다.');
+        toast.error('선택한 상품 삭제에 실패했습니다.');
       }
     }
   };

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Toast } from '@/components';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Toast/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    message: {
+      control: 'text',
+      description: '토스트에 표시할 메시지',
+    },
+    type: {
+      control: { type: 'radio' },
+      options: ['success', 'error'],
+      description: '토스트 유형 (성공/오류)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+export const Success: Story = {
+  args: {
+    message: '성공적으로 처리되었습니다.',
+    type: 'success',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    message: '오류가 발생했습니다. 다시 시도해주세요.',
+    type: 'error',
+  },
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './cn';
 export * from './calculateDiscountRate';
 export * from './getMswEndpoint';
 export * from './hydration';
+export * from './toast';

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { toast as sonnerToast } from 'sonner';
+
+import { Toast } from '@/components';
+
+type ToastType = 'success' | 'error';
+
+interface ToastOptions {
+  type?: ToastType;
+  duration?: number;
+}
+
+export const toast = {
+  success: (message: string, options?: Omit<ToastOptions, 'type'>) => {
+    return sonnerToast.custom(
+      () => <Toast message={message} type="success" />,
+      { duration: options?.duration || 3000 },
+    );
+  },
+
+  error: (message: string, options?: Omit<ToastOptions, 'type'>) => {
+    return sonnerToast.custom(() => <Toast message={message} type="error" />, {
+      duration: options?.duration || 3000,
+    });
+  },
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

사용자 인터랙션에 따라 토스트를 추가했어요.

## 🔧 변경 사항

- [sonner](https://sonner.emilkowal.ski/) 라이브러리를 추가했어요.
- Toast 컴포넌트를 만들고 스토리북을 작성했어요.
- `toast` 유틸함수를 만들었어요. (success와 error 타입으로 사용할 수 있어요.) → 컬러, 폰트 사이즈는 변경하셔도 됩니다.
- 장바구니에서 사용자 인터랙션이 있는 곳에 토스트를 추가했어요.

## 📸 스크린샷

스토리북으로 확인하면 됩니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
