### PR TITLE
[✨ feat] 결제할 상품 리스트 도착예상일 별 그룹화 리스팅과 order 관련 스토리북 컴포넌트 추가

### DIFF
--- a/src/app/(root)/checkout/page.tsx
+++ b/src/app/(root)/checkout/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation';
 
 import { checkoutOrder } from '@/services';
+import { formatDateAfterDays } from '@/utils';
 import {
-  OrderProductList,
+  OrderProductListGroup,
   CheckoutHeader,
   DeliveryAddress,
   PaymentMethodSelector,
@@ -63,13 +64,23 @@ const OrderCheckoutPage = async ({ searchParams }: OrderCheckoutPageProps) => {
     orderItems,
   } = await checkoutOrder(payload);
 
+  // 현재 날짜로 부터 3~7일 뒤 'yyyy-mm-dd'로 배송 날짜 예정
+  const getDeliveredAt = () =>
+    formatDateAfterDays(Math.floor(Math.random() * 5) + 3);
+
+  const updatedOrderItems = orderItems.map(item =>
+    !item.deliveredAt
+      ? { ...item, ...{ deliveredAt: getDeliveredAt() } }
+      : item,
+  );
+
   const address = {
     recipientName: '엘리자베스',
     recipientPhone: '01012344321',
     recipientAddress: '깐따비야 안드로메다 행성',
     zipCode: '99999',
     note: '안전한 우주 배송 화이팅!!',
-    recipientEmail: 'goldegg127@gmail.com',
+    recipientEmail: 'XXX@gmail.com',
   };
 
   const adressContainerStyles = 'flex flex-col gap-sm';
@@ -89,7 +100,7 @@ const OrderCheckoutPage = async ({ searchParams }: OrderCheckoutPageProps) => {
         <SectionHeadingTitle className="leading-none">
           결제 상품 정보
         </SectionHeadingTitle>
-        <OrderProductList orderItems={orderItems} />
+        <OrderProductListGroup orderItems={updatedOrderItems} />
       </section>
 
       <section>
@@ -102,14 +113,14 @@ const OrderCheckoutPage = async ({ searchParams }: OrderCheckoutPageProps) => {
         />
       </section>
 
-      <section className="h-[510px] md:h-[580px]">
+      <section className="h-[610px] md:h-[680px]">
         <SectionHeadingTitle>결제 수단</SectionHeadingTitle>
         <PaymentMethodSelector
           totalDiscountAmount={totalDiscountAmount}
           totalProductAmount={totalProductAmount}
           deliveryFee={deliveryFee}
           totalAmount={totalAmount}
-          orderItems={orderItems}
+          orderItems={updatedOrderItems}
           {...address}
         />
       </section>

--- a/src/components/orders-payments/OrderProductList/OrderProductList.tsx
+++ b/src/components/orders-payments/OrderProductList/OrderProductList.tsx
@@ -1,115 +1,71 @@
-import {
-  cn,
-  formatDateWithDay,
-  formatDateAfterDays,
-  formatAfterDays,
-} from '@/utils';
+import { cn, formatAfterDays } from '@/utils';
 import type { OrderItem } from '@/types';
 import { ProductThumbnail } from '@/components';
 import { default as ProductName } from './ProductName';
 import { default as ProductAmoutInfo } from './ProductAmoutInfo';
+import { default as ProductOptionInfo } from './ProductOptionInfo';
 
 interface OrderProductListProps {
-  orderItems: OrderItem[];
+  orderItems: Required<OrderItem>[];
+  gapStyles?: string;
 }
 
-const OrderProductList = ({ orderItems }: OrderProductListProps) => {
-  const deliveredAt = formatDateAfterDays(Math.floor(Math.random() * 5) + 3); // 현재 날짜로 부터 3~7일 뒤 'yyyy-mm-dd'로 배송 날짜 예정
-  const paddingStyles = 'py-md md:py-lg pr-md md:pr-lg first:pt-0';
-  const gapStyles = `flex gap-md md:gap-lg`;
-  const thumbColumnStyles = 'w-5/12 w-[120px] md:w-[200px]';
-  const infoColumnStyles = 'w-7/12 md:w-full';
+const OrderProductList = ({ orderItems, gapStyles }: OrderProductListProps) => {
+  const paddingStyles = 'py-md sm:py-lg pr-md sm:pr-lg first:pt-0';
+  const thumbColumnStyles = 'w-5/12 w-[120px] sm:w-[200px]';
+  const infoColumnStyles = 'w-7/12 sm:w-full';
 
   return (
-    <article className={cn('flex-col', gapStyles)}>
-      <div className="gap-xs flex text-xl">
-        <strong className="text-text-info">
-          {formatDateWithDay(deliveredAt)}
-        </strong>
-        <span>도착 예정</span>
-      </div>
-      <ul>
-        {orderItems.map(item => (
-          <li
-            key={item.productItemId}
-            className={cn(
-              paddingStyles,
-              'md:border-border-secondary md:border-b',
-            )}
-          >
-            <article>
-              <div className={gapStyles}>
-                <div className={thumbColumnStyles}>
-                  <ProductThumbnail
-                    width="w-full"
-                    className="aspect-200/175"
-                    imageUrl={item.productImgUrl}
-                    name={item.productName}
-                  />
-                </div>
-                <div
-                  className={cn(
-                    'gap-2xs flex flex-1 flex-col',
-                    infoColumnStyles,
-                  )}
-                >
-                  <ProductName productName={item.productName} />
-                  <ProductAmoutInfo
-                    className="hidden md:flex"
-                    price={item.price}
-                    quantity={item.quantity}
-                    deliveredAt={deliveredAt}
-                  />
-                  <ProductOption
+    <ul>
+      {orderItems.map(item => (
+        <li
+          key={item.productItemId}
+          className={cn(paddingStyles, 'border-border-secondary border-b')}
+        >
+          <article className={cn('flex-col', gapStyles)}>
+            <div className={cn(gapStyles, 'items-center')}>
+              <div className={thumbColumnStyles}>
+                <ProductThumbnail
+                  width="w-full"
+                  className="aspect-200/175"
+                  imageUrl={item.productImgUrl}
+                  name={item.productName}
+                />
+              </div>
+              <div
+                className={cn('gap-md flex flex-1 flex-col', infoColumnStyles)}
+              >
+                <ProductName productName={item.productName} />
+
+                {item.firstOptionValue ? (
+                  <ProductOptionInfo
                     firstOptionValue={item.firstOptionValue}
                     secondOptionValue={item.secondOptionValue}
                   />
-                </div>
-              </div>
-              <div className="md:hidden">
+                ) : (
+                  ''
+                )}
+
                 <ProductAmoutInfo
+                  className="hidden sm:flex"
                   price={item.price}
                   quantity={item.quantity}
-                  deliveredAt={formatAfterDays(deliveredAt)}
-                  className="justify-center"
+                  deliveredAt={item.deliveredAt}
                 />
               </div>
-            </article>
-          </li>
-        ))}
-      </ul>
-    </article>
-  );
-};
-
-interface ProductOptionProps {
-  firstOptionValue: string;
-  secondOptionValue: string;
-  className?: string;
-}
-
-const ProductOption = ({
-  firstOptionValue,
-  secondOptionValue,
-  className,
-}: ProductOptionProps) => {
-  return (
-    <div
-      className={cn(
-        'gap-sm text-text-tertiary flex text-sm font-normal md:text-base',
-        className,
-      )}
-    >
-      <span>{firstOptionValue}</span>
-      {secondOptionValue ? (
-        <>
-          <i>·</i>
-          <span>{secondOptionValue}</span>
-        </>
-      ) : (
-        ''
-      )}
-    </div>
+            </div>
+            <div className="sm:hidden">
+              <ProductAmoutInfo
+                price={item.price}
+                quantity={item.quantity}
+                deliveredAt={formatAfterDays(item.deliveredAt)}
+                className="justify-center"
+              />
+            </div>
+          </article>
+        </li>
+      ))}
+    </ul>
   );
 };
 

--- a/src/components/orders-payments/OrderProductList/OrderProductList.tsx
+++ b/src/components/orders-payments/OrderProductList/OrderProductList.tsx
@@ -30,46 +30,51 @@ const OrderProductList = ({ orderItems }: OrderProductListProps) => {
       </div>
       <ul>
         {orderItems.map(item => (
-          <li key={item.productItemId}>
-            <article
-              className={cn(
-                'md:border-border-secondary md:border-b',
-                paddingStyles,
-                gapStyles,
-              )}
-            >
-              <div className={thumbColumnStyles}>
-                <ProductThumbnail
-                  width="w-full"
-                  className="aspect-200/175"
-                  imageUrl={item.productImgUrl}
-                  name={item.productName}
-                />
+          <li
+            key={item.productItemId}
+            className={cn(
+              paddingStyles,
+              'md:border-border-secondary md:border-b',
+            )}
+          >
+            <article>
+              <div className={gapStyles}>
+                <div className={thumbColumnStyles}>
+                  <ProductThumbnail
+                    width="w-full"
+                    className="aspect-200/175"
+                    imageUrl={item.productImgUrl}
+                    name={item.productName}
+                  />
+                </div>
+                <div
+                  className={cn(
+                    'gap-2xs flex flex-1 flex-col',
+                    infoColumnStyles,
+                  )}
+                >
+                  <ProductName productName={item.productName} />
+                  <ProductAmoutInfo
+                    className="hidden md:flex"
+                    price={item.price}
+                    quantity={item.quantity}
+                    deliveredAt={deliveredAt}
+                  />
+                  <ProductOption
+                    firstOptionValue={item.firstOptionValue}
+                    secondOptionValue={item.secondOptionValue}
+                  />
+                </div>
               </div>
-              <div
-                className={cn('gap-2xs flex flex-1 flex-col', infoColumnStyles)}
-              >
-                <ProductName productName={item.productName} />
+              <div className="md:hidden">
                 <ProductAmoutInfo
-                  className="hidden md:flex"
                   price={item.price}
                   quantity={item.quantity}
-                  deliveredAt={deliveredAt}
-                />
-                <ProductOption
-                  firstOptionValue={item.firstOptionValue}
-                  secondOptionValue={item.secondOptionValue}
+                  deliveredAt={formatAfterDays(deliveredAt)}
+                  className="justify-center"
                 />
               </div>
             </article>
-            <div className="md:hidden">
-              <ProductAmoutInfo
-                price={item.price}
-                quantity={item.quantity}
-                deliveredAt={formatAfterDays(deliveredAt)}
-                className="justify-center"
-              />
-            </div>
           </li>
         ))}
       </ul>
@@ -91,8 +96,8 @@ const ProductOption = ({
   return (
     <div
       className={cn(
-        className,
         'gap-sm text-text-tertiary flex text-sm font-normal md:text-base',
+        className,
       )}
     >
       <span>{firstOptionValue}</span>

--- a/src/components/orders-payments/OrderProductList/OrderProductList.tsx
+++ b/src/components/orders-payments/OrderProductList/OrderProductList.tsx
@@ -37,13 +37,11 @@ const OrderProductList = ({ orderItems, gapStyles }: OrderProductListProps) => {
               >
                 <ProductName productName={item.productName} />
 
-                {item.firstOptionValue ? (
+                {item.firstOptionValue && (
                   <ProductOptionInfo
                     firstOptionValue={item.firstOptionValue}
                     secondOptionValue={item.secondOptionValue}
                   />
-                ) : (
-                  ''
                 )}
 
                 <ProductAmoutInfo

--- a/src/components/orders-payments/OrderProductList/OrderProductList.tsx
+++ b/src/components/orders-payments/OrderProductList/OrderProductList.tsx
@@ -50,7 +50,7 @@ const OrderProductList = ({ orderItems, gapStyles }: OrderProductListProps) => {
                   className="hidden sm:flex"
                   price={item.price}
                   quantity={item.quantity}
-                  deliveredAt={item.deliveredAt}
+                  deliveredAt={formatAfterDays(item.deliveredAt)}
                 />
               </div>
             </div>

--- a/src/components/orders-payments/OrderProductList/OrderProductListGroup.tsx
+++ b/src/components/orders-payments/OrderProductList/OrderProductListGroup.tsx
@@ -1,0 +1,36 @@
+import {
+  cn,
+  formatDateWithDay,
+  getGroupedOrderItemsByDeliveredAt,
+} from '@/utils';
+import type { OrderItem } from '@/types';
+import { default as OrderProductList } from './OrderProductList';
+
+interface OrderProductListProps {
+  orderItems: OrderItem[];
+}
+
+const OrderProductListGroup = ({ orderItems }: OrderProductListProps) => {
+  const updatedOrderItems = getGroupedOrderItemsByDeliveredAt(orderItems);
+  const gapStyles = `flex gap-md sm:gap-lg`;
+
+  return (
+    <ul className={cn('flex-col', gapStyles)}>
+      {updatedOrderItems.map(({ deliveredAt, items }) => (
+        <li key={deliveredAt}>
+          <article className={cn('flex-col', gapStyles)}>
+            <div className="gap-xs flex text-xl">
+              <strong className="text-text-info">
+                {formatDateWithDay(deliveredAt)}
+              </strong>
+              <span>도착 예정</span>
+            </div>
+            <OrderProductList orderItems={items} gapStyles={gapStyles} />
+          </article>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default OrderProductListGroup;

--- a/src/components/orders-payments/OrderProductList/ProductAmoutInfo.tsx
+++ b/src/components/orders-payments/OrderProductList/ProductAmoutInfo.tsx
@@ -15,11 +15,11 @@ const ProductAmoutInfo = ({
 }: ProductAmoutInfoProps) => {
   return (
     <div className={cn('gap-sm flex items-center font-semibold', className)}>
-      <strong className="font-style-heading font-semibold">
+      <strong className="font-style-heading leading-none font-semibold">
         {formatPrice(price)}
       </strong>
       <span className="before:pr-sm after:pl-sm text-text-tertiaryInfo before:content-['·'] after:content-['·']">
-        {quantity}
+        {quantity} 개
       </span>
       <strong className="text-text-primaryInteraction text-base font-semibold md:text-lg">
         {deliveredAt}

--- a/src/components/orders-payments/OrderProductList/ProductOptionInfo.tsx
+++ b/src/components/orders-payments/OrderProductList/ProductOptionInfo.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils';
+
+interface ProductOptionInfoProps {
+  firstOptionValue: string | null;
+  secondOptionValue: string | null;
+  className?: string;
+}
+
+const ProductOptionInfo = ({
+  firstOptionValue,
+  secondOptionValue,
+  className,
+}: ProductOptionInfoProps) => {
+  return (
+    <div
+      className={cn(
+        'gap-sm text-text-tertiary flex text-sm font-normal md:text-base',
+        className,
+      )}
+    >
+      <span>{firstOptionValue}</span>
+      {secondOptionValue ? (
+        <>
+          <i>·</i>
+          <span>{secondOptionValue}</span>
+        </>
+      ) : (
+        ''
+      )}
+    </div>
+  );
+};
+
+export default ProductOptionInfo;

--- a/src/components/orders-payments/OrderProductList/ProductOptionInfo.tsx
+++ b/src/components/orders-payments/OrderProductList/ProductOptionInfo.tsx
@@ -19,13 +19,11 @@ const ProductOptionInfo = ({
       )}
     >
       <span>{firstOptionValue}</span>
-      {secondOptionValue ? (
+      {secondOptionValue && (
         <>
           <i>·</i>
           <span>{secondOptionValue}</span>
         </>
-      ) : (
-        ''
       )}
     </div>
   );

--- a/src/components/orders-payments/OrderProductList/index.ts
+++ b/src/components/orders-payments/OrderProductList/index.ts
@@ -1,1 +1,2 @@
 export { default as OrderProductList } from './OrderProductList';
+export { default as OrderProductListGroup } from './OrderProductListGroup';

--- a/src/components/orders-payments/index.ts
+++ b/src/components/orders-payments/index.ts
@@ -3,4 +3,4 @@ export { default as DeliveryAddress } from './DeliveryAddress';
 export { default as PaymentMethodSelector } from './PaymentMethodSelector';
 export { default as PaymentSummary } from './PaymentSummary';
 export { default as SectionHeadingTitle } from './SectionHeadingTitle';
-export { OrderProductList } from './OrderProductList';
+export * from './OrderProductList';

--- a/src/stories/orders/OrderProductListGroup.stories.tsx
+++ b/src/stories/orders/OrderProductListGroup.stories.tsx
@@ -11,11 +11,8 @@ const OrderProductListGroupMock = ({
   return <OrderProductListGroup orderItems={orderItems} />;
 };
 
-const sampleImage1 =
+const sampleImage =
   'https://cdn-optimized.imweb.me/upload/S20240328110100ace0842/55757f8d5f03e.jpg';
-
-const sampleImage2 =
-  'https://shopping-phinf.pstatic.net/main_8903804/89038041158.jpg';
 
 const createOrderItems = (): OrderItem[] => [
   {
@@ -23,7 +20,7 @@ const createOrderItems = (): OrderItem[] => [
     storeName: '라이프스타일 트렌드',
     productItemId: 11,
     productName: '풀커버 강화유리 액정보호필름 갤럭시노트20, 2매입',
-    productImgUrl: sampleImage1,
+    productImgUrl: sampleImage,
     firstOptionName: '사생활보호',
     firstOptionValue: '유',
     secondOptionName: '모서리',
@@ -37,14 +34,14 @@ const createOrderItems = (): OrderItem[] => [
     storeName: '꼼꼼이몰',
     productItemId: 22,
     productName: '캐논 G3910 정품 무한잉크',
-    productImgUrl: sampleImage2,
+    productImgUrl: sampleImage,
     firstOptionName: '색상',
     firstOptionValue: '보라',
     secondOptionName: null,
     secondOptionValue: null,
     quantity: 1,
     price: 35310,
-    deliveredAt: '2025-04-03',
+    deliveredAt: '2025-04-05',
   },
   {
     storeId: 4,
@@ -52,45 +49,42 @@ const createOrderItems = (): OrderItem[] => [
     productItemId: 8,
     productName:
       '케이스 카드 2장 포켓 수납 파스텔 카메라 풀커버 실리콘 젤리 라벤더, 갤럭시S25 플러스',
-    productImgUrl:
-      'https://shopping-phinf.pstatic.net/main_8883236/88832360690.jpg',
+    productImgUrl: sampleImage,
     firstOptionName: null,
     firstOptionValue: null,
     secondOptionName: null,
     secondOptionValue: null,
     quantity: 1,
     price: 14770,
-    deliveredAt: '2025-04-03',
+    deliveredAt: '2025-04-04',
   },
   {
     storeId: 3,
     storeName: 'Marshall 공식몰',
     productItemId: 320,
     productName: '[본사최신제품]인셀덤 크림 엑티브 50ml EX 수분 이엑스',
-    productImgUrl:
-      'https://shopping-phinf.pstatic.net/main_8597946/85979463969.jpg',
+    productImgUrl: sampleImage,
     firstOptionName: null,
     firstOptionValue: null,
     secondOptionName: null,
     secondOptionValue: null,
     quantity: 1,
     price: 49790,
-    deliveredAt: '2025-04-03',
+    deliveredAt: '2025-04-10',
   },
   {
     storeId: 4,
     storeName: '홈 & 테크 쇼핑몰',
     productItemId: 447,
     productName: '프로쉬 알로에베라 고농축 세탁세제 3L',
-    productImgUrl:
-      'https://shopping-phinf.pstatic.net/main_2835180/28351801555.20230727161156.jpg',
+    productImgUrl: sampleImage,
     firstOptionName: null,
     firstOptionValue: null,
     secondOptionName: null,
     secondOptionValue: null,
     quantity: 2,
     price: 10480,
-    deliveredAt: '2025-04-03',
+    deliveredAt: '2025-04-10',
   },
   {
     storeId: 7,
@@ -98,15 +92,14 @@ const createOrderItems = (): OrderItem[] => [
     productItemId: 370,
     productName:
       '르네 디종 프렌치 머스타드 850g 식자재 식료품 가공식품 수입식품 수입식재료',
-    productImgUrl:
-      'https://shopping-phinf.pstatic.net/main_8865835/88658359418.jpg',
+    productImgUrl: sampleImage,
     firstOptionName: null,
     firstOptionValue: null,
     secondOptionName: null,
     secondOptionValue: null,
     quantity: 1,
     price: 14910,
-    deliveredAt: '2025-04-03',
+    deliveredAt: '2025-04-04',
   },
 ];
 

--- a/src/stories/orders/OrderProductListGroup.stories.tsx
+++ b/src/stories/orders/OrderProductListGroup.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { OrderProductListGroup } from '@/components';
+import type { OrderItem } from '@/types';
+
+const OrderProductListGroupMock = ({
+  orderItems,
+}: {
+  orderItems: OrderItem[];
+}) => {
+  return <OrderProductListGroup orderItems={orderItems} />;
+};
+
+const sampleImage1 =
+  'https://cdn-optimized.imweb.me/upload/S20240328110100ace0842/55757f8d5f03e.jpg';
+
+const sampleImage2 =
+  'https://shopping-phinf.pstatic.net/main_8903804/89038041158.jpg';
+
+const createOrderItems = (): OrderItem[] => [
+  {
+    storeId: 5,
+    storeName: '라이프스타일 트렌드',
+    productItemId: 11,
+    productName: '풀커버 강화유리 액정보호필름 갤럭시노트20, 2매입',
+    productImgUrl: sampleImage1,
+    firstOptionName: '사생활보호',
+    firstOptionValue: '유',
+    secondOptionName: '모서리',
+    secondOptionValue: '풀커버',
+    quantity: 2,
+    price: 10930,
+    deliveredAt: '2025-04-03',
+  },
+  {
+    storeId: 9,
+    storeName: '꼼꼼이몰',
+    productItemId: 22,
+    productName: '캐논 G3910 정품 무한잉크',
+    productImgUrl: sampleImage2,
+    firstOptionName: '색상',
+    firstOptionValue: '보라',
+    secondOptionName: null,
+    secondOptionValue: null,
+    quantity: 1,
+    price: 35310,
+    deliveredAt: '2025-04-03',
+  },
+  {
+    storeId: 4,
+    storeName: '홈 & 테크 쇼핑몰',
+    productItemId: 8,
+    productName:
+      '케이스 카드 2장 포켓 수납 파스텔 카메라 풀커버 실리콘 젤리 라벤더, 갤럭시S25 플러스',
+    productImgUrl:
+      'https://shopping-phinf.pstatic.net/main_8883236/88832360690.jpg',
+    firstOptionName: null,
+    firstOptionValue: null,
+    secondOptionName: null,
+    secondOptionValue: null,
+    quantity: 1,
+    price: 14770,
+    deliveredAt: '2025-04-03',
+  },
+  {
+    storeId: 3,
+    storeName: 'Marshall 공식몰',
+    productItemId: 320,
+    productName: '[본사최신제품]인셀덤 크림 엑티브 50ml EX 수분 이엑스',
+    productImgUrl:
+      'https://shopping-phinf.pstatic.net/main_8597946/85979463969.jpg',
+    firstOptionName: null,
+    firstOptionValue: null,
+    secondOptionName: null,
+    secondOptionValue: null,
+    quantity: 1,
+    price: 49790,
+    deliveredAt: '2025-04-03',
+  },
+  {
+    storeId: 4,
+    storeName: '홈 & 테크 쇼핑몰',
+    productItemId: 447,
+    productName: '프로쉬 알로에베라 고농축 세탁세제 3L',
+    productImgUrl:
+      'https://shopping-phinf.pstatic.net/main_2835180/28351801555.20230727161156.jpg',
+    firstOptionName: null,
+    firstOptionValue: null,
+    secondOptionName: null,
+    secondOptionValue: null,
+    quantity: 2,
+    price: 10480,
+    deliveredAt: '2025-04-03',
+  },
+  {
+    storeId: 7,
+    storeName: '살림의여왕',
+    productItemId: 370,
+    productName:
+      '르네 디종 프렌치 머스타드 850g 식자재 식료품 가공식품 수입식품 수입식재료',
+    productImgUrl:
+      'https://shopping-phinf.pstatic.net/main_8865835/88658359418.jpg',
+    firstOptionName: null,
+    firstOptionValue: null,
+    secondOptionName: null,
+    secondOptionValue: null,
+    quantity: 1,
+    price: 14910,
+    deliveredAt: '2025-04-03',
+  },
+];
+
+const meta: Meta<typeof OrderProductListGroupMock> = {
+  title: 'Orders/OrderProductList',
+  component: OrderProductListGroupMock,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="container mx-auto p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OrderProductListGroupMock>;
+
+export const ProductListGroupForCheckout: Story = {
+  args: {
+    orderItems: createOrderItems(),
+  },
+};

--- a/src/types/ordersType.ts
+++ b/src/types/ordersType.ts
@@ -9,12 +9,18 @@ export interface OrderItem {
   productItemId: number;
   productName: string;
   productImgUrl: string;
-  firstOptionName: string;
-  firstOptionValue: string;
-  secondOptionName: string;
-  secondOptionValue: string;
+  firstOptionName: string | null;
+  firstOptionValue: string | null;
+  secondOptionName: string | null;
+  secondOptionValue: string | null;
   quantity: number;
   price: number;
+  deliveredAt: string;
+}
+
+export interface GroupedOrderItemByDeliveredAt {
+  deliveredAt: string;
+  items: OrderItem[];
 }
 
 // 주문서 요청 API 스키마
@@ -44,7 +50,7 @@ export interface OrderDetailResponseAPISchema {
   paidAt: string;
   deliveredAt: string;
   completedAt: string;
-  orderItems: OrderItem[];
+  orderItems: Omit<OrderItem[], 'deliveredAt'>;
   recipientName: string;
   recipientPhone: string;
   recipientAddress: string;

--- a/src/utils/dataTransformUtils.ts
+++ b/src/utils/dataTransformUtils.ts
@@ -1,0 +1,35 @@
+import type { OrderItem, GroupedOrderItemByDeliveredAt } from '@/types';
+
+/**
+ * deliveredAt 속성을 기준으로 데이터를 그룹화하여 변환
+ * @param data
+ * @returns 날짜별로 그룹화된 객체 배열
+ */
+export const getGroupedOrderItemsByDeliveredAt = (
+  data: OrderItem[],
+): GroupedOrderItemByDeliveredAt[] => {
+  const groupedByDate: { [key: string]: OrderItem[] } = {};
+
+  data.forEach(item => {
+    const date = item.deliveredAt;
+
+    if (!groupedByDate[date]) {
+      groupedByDate[date] = [];
+    }
+
+    groupedByDate[date].push(item);
+  });
+
+  const result: GroupedOrderItemByDeliveredAt[] = Object.entries(
+    groupedByDate,
+  ).map(([date, items]) => {
+    return {
+      deliveredAt: date,
+      items: items,
+    };
+  });
+
+  result.sort((a, b) => a.deliveredAt.localeCompare(b.deliveredAt));
+
+  return result;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './reviewCache';
 export * from './calculateRelativeTime';
 export * from './toast';
 export * from './format';
+export * from './dataTransformUtils';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 도착일 날짜별로 그룹화 되도록 상품 리스트 구조 변경  
- 그룹화 리스트 컴포넌트 추가 생성 
- orderItems의 데이터를 도착일 별 그룹화하는 유틸함수 생성
- order 관련 컴포넌트 스토리북 추가

## 🔧 변경 사항

- 첫번째 항목의 padding-top의 값을 0으로 만들려 했으나 모든 리스트의 padding-top이 0으로 적용된 이슈 수정
- 날짜별 그룹화 UI 추가

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
