### PR TITLE
[✨ feat] 리뷰 감성분석 기능 추가

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -14,6 +14,7 @@ export type ButtonVariant =
   | 'secondaryOutline'
   | 'disabled'
   | 'tertiaryOutline'
+  | 'tertiaryOutlineInteraction'
   | 'transparent'
   | 'likeOn'
   | 'likeOff';
@@ -55,6 +56,8 @@ const Button = ({
     disabled: 'bg-bg-disabled text-text-disabled cursor-not-allowed',
     tertiaryOutline:
       'border border-border-disabled bg-bg-primary text-text-disabled',
+    tertiaryOutlineInteraction:
+      'border border-border-disabled bg-bg-primary text-text-disabled hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed',
     transparent: 'text-text-secondaryInteration',
     likeOn: 'border-bg-subBrand text-text-visited border',
     likeOff: 'border border-border-primary text-secondaryInteration',

--- a/src/components/reviews/create-review/CreateReviewButtonBox.tsx
+++ b/src/components/reviews/create-review/CreateReviewButtonBox.tsx
@@ -4,12 +4,21 @@ import { useRouter } from 'next/navigation';
 
 import { Button } from '@/components';
 
-const CreateReviewButtonBox = () => {
+interface CreateReviewButtonBoxProps {
+  isCreateReviewPending: boolean;
+}
+
+const CreateReviewButtonBox = ({
+  isCreateReviewPending,
+}: CreateReviewButtonBoxProps) => {
   const { back } = useRouter();
 
   const handleCancel = () => {
     back();
   };
+
+  const submitText = isCreateReviewPending ? '리뷰등록 중' : '리뷰등록';
+  const submitVariant = isCreateReviewPending ? 'disabled' : 'primary';
 
   return (
     <div className="gap-sm flex w-full">
@@ -21,8 +30,8 @@ const CreateReviewButtonBox = () => {
       >
         작성취소
       </Button>
-      <Button type="submit" className="flex-auto">
-        리뷰등록
+      <Button type="submit" className="flex-auto" variant={submitVariant}>
+        {submitText}
       </Button>
     </div>
   );

--- a/src/components/reviews/create-review/ReviewContent.tsx
+++ b/src/components/reviews/create-review/ReviewContent.tsx
@@ -30,10 +30,11 @@ const ReviewContent = ({ orderId, productItemId }: ReviewContentProps) => {
     productItemId,
   );
 
-  const [createReviewState, boundCreateReviewFormAction] = useActionState(
-    boundCreateReviewAction,
-    initialCreateReviewState,
-  );
+  const [
+    createReviewState,
+    boundCreateReviewFormAction,
+    isCreateReviewPending,
+  ] = useActionState(boundCreateReviewAction, initialCreateReviewState);
 
   const handleRatingClick = () => {
     if (!textareaRef.current) return;
@@ -91,7 +92,7 @@ const ReviewContent = ({ orderId, productItemId }: ReviewContentProps) => {
           name="reviewContent"
         />
       </fieldset>
-      <CreateReviewButtonBox />
+      <CreateReviewButtonBox isCreateReviewPending={isCreateReviewPending} />
     </form>
   );
 };

--- a/src/components/reviews/product-review/ReviewBadge.tsx
+++ b/src/components/reviews/product-review/ReviewBadge.tsx
@@ -1,23 +1,40 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import {
+  startTransition,
+  useOptimistic,
+  useState,
+  type ReactNode,
+} from 'react';
 
-import { Icon } from '@/components';
 import { cn } from '@/utils';
+import { sentimentFeedbackAction } from '@/server-actions';
+import { Icon } from '@/components';
 
 interface ReviewBadgeProps {
   type: 'positive' | 'negative';
-  children: ReactNode;
   textSize: 'subHeading' | 'paragraph';
+  reviewText: string;
+  children: ReactNode;
 }
 
-const ReviewBadge = ({ type, children, textSize }: ReviewBadgeProps) => {
+const ReviewBadge = ({
+  type,
+  textSize,
+  reviewText,
+  children,
+}: ReviewBadgeProps) => {
   const [hover, setHover] = useState(false);
+  const [optimisticFeedback, setOptimisticFeedback] = useOptimistic(
+    false,
+    (_, newState: boolean) => newState,
+  );
 
   const defaultClass = {
     bg: 'gap-xs px-sm py-xs items-center rounded-xl inline-flex border border-transparent',
     text: `font-style-${textSize}`,
   };
+
   const typeClass =
     type === 'positive'
       ? {
@@ -31,29 +48,57 @@ const ReviewBadge = ({ type, children, textSize }: ReviewBadgeProps) => {
           text: 'text-text-dangerBold',
         };
   const hoverClass = {
-    bg: 'box-border border hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed cursor-pointer',
-    icon: 'hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed',
-    text: 'hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed',
+    bg: `cursor-pointer border ${type === 'positive' ? 'border-border-success' : 'border-border-danger'}`,
+    icon: `fill-current ${type === 'positive' ? 'text-icon-success' : 'text-icon-danger'}`,
   };
-  const badgeClass = hover && textSize === 'paragraph' ? hoverClass : typeClass;
+
   const hoverText =
     type === 'positive'
       ? '긍정적인 반응의 리뷰가 아니에요'
       : '부정적인 반응의 리뷰가 아니에요';
-  const badgeText = hover && textSize === 'paragraph' ? hoverText : children;
+  const badgeText =
+    !hover && textSize === 'paragraph'
+      ? children
+      : optimisticFeedback
+        ? '소중한 피드백을 전송 완료했어요'
+        : hoverText;
+
+  const iconName =
+    !hover && textSize === 'paragraph'
+      ? type
+      : optimisticFeedback
+        ? 'check'
+        : 'view'; // 📌 thinking 아이콘으로 수정 필요!
 
   const handleHover = () => {
     setHover(prev => !prev);
+  };
+
+  const handleClick = () => {
+    if (textSize === 'paragraph' && !optimisticFeedback) {
+      startTransition(() => {
+        setOptimisticFeedback(!optimisticFeedback);
+
+        sentimentFeedbackAction(reviewText, type).catch(error => {
+          console.error('피드백 제출 실패:', error);
+          setOptimisticFeedback(optimisticFeedback);
+        });
+      });
+    }
   };
 
   return (
     <div
       onMouseEnter={handleHover}
       onMouseLeave={handleHover}
-      className={cn(defaultClass.bg, badgeClass.bg)}
+      onClick={handleClick}
+      className={cn(defaultClass.bg, typeClass.bg, hover && hoverClass.bg)}
     >
-      <Icon iconName={type} className={badgeClass.icon} />
-      <div className={cn(defaultClass.text, badgeClass.text)}>{badgeText}</div>
+      <Icon
+        iconName={iconName}
+        className={cn(typeClass.icon, hover && hoverClass.icon)}
+      />
+      <div className={cn(defaultClass.text, typeClass.text)}>{badgeText}</div>
     </div>
   );
 };

--- a/src/components/reviews/product-review/ReviewBadge.tsx
+++ b/src/components/reviews/product-review/ReviewBadge.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+'use client';
+
+import { useState, type ReactNode } from 'react';
 
 import { Icon } from '@/components';
 import { cn } from '@/utils';
@@ -10,11 +12,12 @@ interface ReviewBadgeProps {
 }
 
 const ReviewBadge = ({ type, children, textSize }: ReviewBadgeProps) => {
+  const [hover, setHover] = useState(false);
+
   const defaultClass = {
-    bg: 'gap-xs px-sm py-xs items-center rounded-xl inline-flex',
+    bg: 'gap-xs px-sm py-xs items-center rounded-xl inline-flex border border-transparent',
     text: `font-style-${textSize}`,
   };
-
   const typeClass =
     type === 'positive'
       ? {
@@ -27,11 +30,30 @@ const ReviewBadge = ({ type, children, textSize }: ReviewBadgeProps) => {
           icon: 'text-icon-danger',
           text: 'text-text-dangerBold',
         };
+  const hoverClass = {
+    bg: 'box-border border hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed cursor-pointer',
+    icon: 'hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed',
+    text: 'hover:border-border-primaryHover hover:text-text-primaryHover active:border-border-primaryPressed active:text-text-primaryPressed',
+  };
+  const badgeClass = hover && textSize === 'paragraph' ? hoverClass : typeClass;
+  const hoverText =
+    type === 'positive'
+      ? '긍정적인 반응의 리뷰가 아니에요'
+      : '부정적인 반응의 리뷰가 아니에요';
+  const badgeText = hover && textSize === 'paragraph' ? hoverText : children;
+
+  const handleHover = () => {
+    setHover(prev => !prev);
+  };
 
   return (
-    <div className={cn(defaultClass.bg, typeClass.bg)}>
-      <Icon iconName={type} className={typeClass.icon} />
-      <div className={cn(defaultClass.text, typeClass.text)}>{children}</div>
+    <div
+      onMouseEnter={handleHover}
+      onMouseLeave={handleHover}
+      className={cn(defaultClass.bg, badgeClass.bg)}
+    >
+      <Icon iconName={type} className={badgeClass.icon} />
+      <div className={cn(defaultClass.text, badgeClass.text)}>{badgeText}</div>
     </div>
   );
 };

--- a/src/components/reviews/product-review/ReviewBadge.tsx
+++ b/src/components/reviews/product-review/ReviewBadge.tsx
@@ -14,7 +14,7 @@ import { Icon } from '@/components';
 interface ReviewBadgeProps {
   type: 'positive' | 'negative';
   textSize: 'subHeading' | 'paragraph';
-  reviewText: string;
+  reviewText?: string;
   children: ReactNode;
 }
 
@@ -79,7 +79,7 @@ const ReviewBadge = ({
       startTransition(() => {
         setOptimisticFeedback(!optimisticFeedback);
 
-        sentimentFeedbackAction(reviewText, type).catch(error => {
+        sentimentFeedbackAction(reviewText || '', type).catch(error => {
           console.error('피드백 제출 실패:', error);
           setOptimisticFeedback(optimisticFeedback);
         });

--- a/src/components/reviews/product-review/ReviewItem.tsx
+++ b/src/components/reviews/product-review/ReviewItem.tsx
@@ -41,7 +41,11 @@ const ReviewItem = ({ ...review }: ReviewItemProps) => {
         {review.content}
       </div>
       <div className="gap-xl flex justify-end">
-        <ReviewBadge textSize="paragraph" type={review.sentiment}>
+        <ReviewBadge
+          textSize="paragraph"
+          type={review.sentiment}
+          reviewText={review.content}
+        >
           {reviewBadgeText}
         </ReviewBadge>
         <ReviewLikeButton isLiked={review.isLiked} id={review.id} />

--- a/src/components/reviews/product-review/ReviewLikeButton.tsx
+++ b/src/components/reviews/product-review/ReviewLikeButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useOptimistic } from 'react';
+import { useOptimistic, startTransition } from 'react';
 
 import { Button } from '@/components';
 import { reviewLikeAction } from '@/server-actions';
@@ -16,24 +16,26 @@ const ReviewLikeButton = ({
 }: ReviewLikeButtonProps) => {
   const [optimisticIsLiked, setOptimisticIsLiked] = useOptimistic(
     initialIsLiked,
-    (newIsLiked: boolean) => newIsLiked,
+    (_, newIsLiked: boolean) => newIsLiked,
   );
 
-  const handleLikeClick = async () => {
-    try {
+  const handleLikeClick = () => {
+    startTransition(() => {
       setOptimisticIsLiked(!optimisticIsLiked);
-      const newIsLiked = await reviewLikeAction(id);
-      setOptimisticIsLiked(newIsLiked);
-    } catch (error) {
-      console.error('좋아요 업데이트 실패:', error);
-      setOptimisticIsLiked(optimisticIsLiked);
-    }
+
+      reviewLikeAction(id).catch(error => {
+        console.error('좋아요 업데이트 실패:', error);
+        setOptimisticIsLiked(optimisticIsLiked);
+      });
+    });
   };
 
   return (
     <Button
       icon={optimisticIsLiked ? 'check' : 'smile'}
-      variant={optimisticIsLiked ? 'primaryOutline' : 'tertiaryOutline'}
+      variant={
+        optimisticIsLiked ? 'primaryOutline' : 'tertiaryOutlineInteraction'
+      }
       onClick={handleLikeClick}
     >
       도움이 되는 리뷰에요

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -79,6 +79,7 @@ export const REVIEW_ENDPOINTS = {
   REVIEW_DETAIL: (reviewId: number) => `${API_RESOURCES.REVIEWS}/${reviewId}`,
   LIKE: (reviewId: number) => `${API_RESOURCES.REVIEWS}/${reviewId}/reviewLike`,
   CREATE_REVIEW: API_RESOURCES.REVIEWS,
+  ANALYZE_SENTIMENT: `${API_RESOURCES.REVIEWS}/analyze-sentiment`,
   REVIEW_FEEDBACK: `${API_RESOURCES.REVIEWS}/feedback`,
 };
 

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -79,6 +79,7 @@ export const REVIEW_ENDPOINTS = {
   REVIEW_DETAIL: (reviewId: number) => `${API_RESOURCES.REVIEWS}/${reviewId}`,
   LIKE: (reviewId: number) => `${API_RESOURCES.REVIEWS}/${reviewId}/reviewLike`,
   CREATE_REVIEW: API_RESOURCES.REVIEWS,
+  REVIEW_FEEDBACK: `${API_RESOURCES.REVIEWS}/feedback`,
 };
 
 export const FAQS_ENDPOINTS = {

--- a/src/server-actions/index.ts
+++ b/src/server-actions/index.ts
@@ -6,3 +6,4 @@ export * from './auth/signinAction';
 export * from './review/reviewLikeAction';
 export * from './review/createReviewAction';
 export * from './faq/faqSearchAction';
+export * from './review/sentimentFeedbackAction';

--- a/src/server-actions/review/reviewLikeAction.ts
+++ b/src/server-actions/review/reviewLikeAction.ts
@@ -1,16 +1,16 @@
 'use server';
 
-import { reviewLike } from '@/services';
 import { revalidateTag } from 'next/cache';
+
+import { reviewLike } from '@/services';
 
 export const reviewLikeAction = async (reviewId: number) => {
   try {
-    const isLiked = await reviewLike(reviewId);
+    const result = await reviewLike(reviewId);
 
-    revalidateTag(`review-${reviewId}`);
     revalidateTag('reviews');
 
-    return isLiked;
+    return result;
   } catch (error) {
     console.error('리뷰 좋아요 실패:', error);
     throw new Error('좋아요 상태 업데이트 실패');

--- a/src/server-actions/review/sentimentFeedbackAction.ts
+++ b/src/server-actions/review/sentimentFeedbackAction.ts
@@ -1,0 +1,23 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { feedbackIncorrectSentiment } from '@/services';
+
+export const sentimentFeedbackAction = async (
+  reviewText: string,
+  sentiment: 'positive' | 'negative',
+) => {
+  try {
+    const result = await feedbackIncorrectSentiment(reviewText, sentiment);
+
+    revalidateTag('reviews');
+
+    console.log('감성분석 피드백 결과: ', result);
+
+    return result;
+  } catch (error) {
+    console.error('감성분석 피드백 제출 실패:', error);
+    throw new Error('감성분석 피드백 제출 실패');
+  }
+};

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -107,6 +107,12 @@ export const fetchReviewPositiveAverage = async (productId: string) => {
   return data;
 };
 
+const analyzeSentiment = async (reviewText: string) => {
+  await axiosInstance.post(REVIEW_ENDPOINTS.ANALYZE_SENTIMENT, {
+    review_text: reviewText,
+  });
+};
+
 export const createReview = async (
   orderId: string,
   productItemId: string,
@@ -125,6 +131,8 @@ export const createReview = async (
     nickname,
     reviewImages: [''],
   });
+
+  await analyzeSentiment(content);
 
   return data;
 };

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -128,3 +128,16 @@ export const createReview = async (
 
   return data;
 };
+
+export const feedbackIncorrectSentiment = async (
+  reviewText: string,
+  sentiment: 'positive' | 'negative',
+) => {
+  const { data } = await axiosInstance.post(REVIEW_ENDPOINTS.REVIEW_FEEDBACK, {
+    review_text: reviewText,
+    sentiment,
+    feedback: 'Incorrect',
+  });
+
+  return data;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 감성 분석 피드백을 위한 UI 및 기능 구현
- 리뷰 등록 시 감성 분석 api를 호출하여 백엔드에서 해당 값을 참조할 수 있도록 구현

## 🔧 변경 사항

- 버튼 컴포넌트의 variant 중 tertiaryOutline에 인터렉션이 전혀 없어 ux 향상을 위한 tertiaryOutlineInteraction 추가
- startTransition으로 useOptimistic의 낙관적 업데이트 처리 방식 개선

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
