### PR TITLE
[✨ feat] 상품 리스트에 목록 가상화 적용 (#194)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/query-core": "^5.69.0",
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",
+    "@tanstack/react-virtual": "^3.13.5",
     "@tosspayments/tosspayments-sdk": "^2.3.4",
     "axios": "^1.8.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.69.0
         version: 5.69.0(@tanstack/react-query@5.69.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.5
+        version: 3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tosspayments/tosspayments-sdk':
         specifier: ^2.3.4
         version: 2.3.4
@@ -1564,6 +1567,15 @@ packages:
     resolution: {integrity: sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.5':
+    resolution: {integrity: sha512-MzSSMGkFWCDSb2xXqmdbfQqBG4wcRI3JKVjpYGZG0CccnViLpfRW4tGU97ImfBbSYzvEWJ/2SK/OiIoSmcUBAA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.5':
+    resolution: {integrity: sha512-gMLNylxhJdUlfRR1G3U9rtuwUh2IjdrrniJIDcekVJN3/3i+bluvdMi3+eodnxzJq5nKnxnigo9h0lIpaqV6HQ==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -6406,6 +6418,14 @@ snapshots:
       '@tanstack/query-core': 5.69.0
       react: 19.0.0
 
+  '@tanstack/react-virtual@3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.5
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  '@tanstack/virtual-core@3.13.5': {}
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -7602,7 +7622,7 @@ snapshots:
       '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
@@ -7626,7 +7646,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -7641,14 +7661,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.25.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7663,7 +7683,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.25.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/category/ClientCategoryProductList.tsx
+++ b/src/components/category/ClientCategoryProductList.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { categoryByIdQueryOptions } from '@/queries';
+import { useProductListVirtualizer } from '@/hooks';
 import type { Product } from '@/types';
 import { ProductItem, ProductListSkeleton } from '../products';
 
@@ -21,17 +22,49 @@ const ClientCategoryProductList = ({
     enabled: !!categoryId,
   });
 
+  const { groupedRows, totalSize, virtualRows, rowVirtualizer } =
+    useProductListVirtualizer({ products: productItems });
+
   if (isPending) {
     return <ProductListSkeleton />;
   }
 
   return (
-    <section>
-      <ul className="gap-x-md gap-y-lg md:gap-y-7xl py-lg md:py-7xl grid sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5">
-        {productItems.map((item: Product) => (
-          <ProductItem key={item.productId} {...item} />
-        ))}
-      </ul>
+    <section className="relative">
+      <div
+        style={{
+          height: `${totalSize}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualRows.map(virtualRow => {
+          const rowIndex = virtualRow.index;
+          const rowItems = groupedRows[rowIndex];
+
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+                height: `${virtualRow.size}px`,
+              }}
+            >
+              <ul className="gap-x-md grid sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5">
+                {rowItems.map((item: Product) => (
+                  <ProductItem key={item.productId} {...item} />
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 };

--- a/src/components/products/ClientProductList.tsx
+++ b/src/components/products/ClientProductList.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { productsQueryOptions } from '@/queries';
+import { useProductListVirtualizer } from '@/hooks';
 import type { Product } from '@/types';
 import ProductItem from './ProductItem';
 
@@ -16,13 +17,45 @@ const ClientProductList = ({
     initialData: initialProducts,
   });
 
+  const { groupedRows, totalSize, virtualRows, rowVirtualizer } =
+    useProductListVirtualizer({ products: productItems });
+
   return (
-    <section>
-      <ul className="gap-x-md gap-y-lg md:gap-y-7xl grid sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5">
-        {productItems.map((item: Product) => (
-          <ProductItem key={item.productId} {...item} />
-        ))}
-      </ul>
+    <section className="relative">
+      <div
+        style={{
+          height: `${totalSize}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualRows.map(virtualRow => {
+          const rowIndex = virtualRow.index;
+          const rowItems = groupedRows[rowIndex];
+
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+                height: `${virtualRow.size}px`,
+              }}
+            >
+              <ul className="gap-x-md grid sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-5">
+                {rowItems.map((item: Product) => (
+                  <ProductItem key={item.productId} {...item} />
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 };

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -4,3 +4,9 @@ export const PRODUCTS_CONSTANTS = {
     mobile: `당신의 쇼핑 데이터를 분석한\n맞춤 ${categoryName} 리스트입니다.`,
   }),
 };
+
+export const PRODUCT_LIST_LAYOUT_CONFIG = {
+  mobile: { columns: 1, estimatedSize: 170, gap: 24 },
+  tablet: { columns: 3, estimatedSize: 424, gap: 80 },
+  desktop: { columns: 5, estimatedSize: 424, gap: 80 },
+};

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,2 +1,3 @@
 export * from './useDebounce';
 export * from './useCart';
+export * from './useProductListVirtualizer';

--- a/src/hooks/common/useProductListVirtualizer.ts
+++ b/src/hooks/common/useProductListVirtualizer.ts
@@ -1,55 +1,63 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 
+import { PRODUCT_LIST_LAYOUT_CONFIG } from '@/constants';
 import type { Product } from '@/types';
 
 const useProductListVirtualizer = ({ products }: { products: Product[] }) => {
-  const [columns, setColumns] = useState(5);
-  const [estimatedSize, setEstimatedSize] = useState(424);
-  const [gap, setGap] = useState(80);
+  const [layoutConfig, setLayoutConfig] = useState(
+    PRODUCT_LIST_LAYOUT_CONFIG.desktop,
+  );
+
+  const handleResize = useCallback(() => {
+    const width = window.innerWidth;
+
+    if (width < 768) {
+      setLayoutConfig(PRODUCT_LIST_LAYOUT_CONFIG.mobile);
+    } else if (width < 1024) {
+      setLayoutConfig(PRODUCT_LIST_LAYOUT_CONFIG.tablet);
+    } else {
+      setLayoutConfig(PRODUCT_LIST_LAYOUT_CONFIG.desktop);
+    }
+  }, []);
 
   useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth;
-      if (width < 768) {
-        setColumns(1);
-        setEstimatedSize(170);
-        setGap(24);
-      } else if (width < 1024) {
-        setColumns(3);
-        setEstimatedSize(424);
-        setGap(80);
-      } else {
-        setColumns(5);
-        setEstimatedSize(424);
-        setGap(80);
-      }
-    };
-
     handleResize();
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    let resizeTimer: NodeJS.Timeout;
+
+    const debouncedResizeHandler = () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(handleResize, 100);
+    };
+
+    window.addEventListener('resize', debouncedResizeHandler);
+    return () => {
+      window.removeEventListener('resize', debouncedResizeHandler);
+      clearTimeout(resizeTimer);
+    };
+  }, [handleResize]);
 
   // 상품 목록을 행 단위로 그룹화
   const groupedRows = useMemo(() => {
     const rowData = [];
+    const { columns } = layoutConfig;
+
     for (let i = 0; i < products.length; i += columns) {
       rowData.push(products.slice(i, i + columns));
     }
     return rowData;
-  }, [products, columns]);
+  }, [products, layoutConfig]);
 
   // 가상화 설정
   const rowVirtualizer = useWindowVirtualizer({
     count: groupedRows.length,
-    estimateSize: () => estimatedSize,
+    estimateSize: () => layoutConfig.estimatedSize,
     overscan: 5,
-    gap,
+    gap: layoutConfig.gap,
   });
 
   const virtualRows = rowVirtualizer.getVirtualItems();

--- a/src/hooks/common/useProductListVirtualizer.ts
+++ b/src/hooks/common/useProductListVirtualizer.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
+
+import type { Product } from '@/types';
+
+const useProductListVirtualizer = ({ products }: { products: Product[] }) => {
+  const [columns, setColumns] = useState(5);
+  const [estimatedSize, setEstimatedSize] = useState(424);
+  const [gap, setGap] = useState(80);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+      if (width < 768) {
+        setColumns(1);
+        setEstimatedSize(170);
+        setGap(24);
+      } else if (width < 1024) {
+        setColumns(3);
+        setEstimatedSize(424);
+        setGap(80);
+      } else {
+        setColumns(5);
+        setEstimatedSize(424);
+        setGap(80);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // 상품 목록을 행 단위로 그룹화
+  const groupedRows = useMemo(() => {
+    const rowData = [];
+    for (let i = 0; i < products.length; i += columns) {
+      rowData.push(products.slice(i, i + columns));
+    }
+    return rowData;
+  }, [products, columns]);
+
+  // 가상화 설정
+  const rowVirtualizer = useWindowVirtualizer({
+    count: groupedRows.length,
+    estimateSize: () => estimatedSize,
+    overscan: 5,
+    gap,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const totalSize = rowVirtualizer.getTotalSize();
+
+  return { virtualRows, totalSize, groupedRows, rowVirtualizer };
+};
+
+export { useProductListVirtualizer };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

현재는 전체 상품 목록이 모두 DOM에 렌더링되고 있어서 LCP가 엄청 길어요. 보이지 않는 영역의 상품들까지 모두 렌더링되고 있어서 불필요한 리소스를 사용하고 있어요.

화면에 보이는 상품만 DOM에 렌더링하고 스크롤 시 필요한 요소만 동적으로 추가하고 제거돼요.
목록 가상화를 적용해서 LCP를 줄여 최적화를 했어요.

## 🔧 변경 사항

- `tanstack/react-virtual`을 사용했어요.
- 상품 목록과 카테고리 상품 목록에서 공통적으로 쓰여 훅으로 따로 제작했어요.
- 반응형에 대응하기 위해 크기 별로 `gap`과 `size`를 지정해줬어요.
- 카테고리 상품 리스트와 모든 상품 리스트에 가상화 훅을 적용했어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

inline css와 같이 작업했는데 이는 동적 값을 처리하기 위해서에요. 
가상화는 픽셀 단위의 정확한 위치 계산을 해야 하고 tailwindcss로 작성하면 우선순위가 상대적으로 높은 인라인 스타일에 덮어씌워질 수 있어요. 