### PR TITLE
[✨ feat] 상품 상세 페이지에 상품 정보 테이블 및 이미지 추가 (#197)

### DIFF
--- a/src/app/(root)/products/[productId]/page.tsx
+++ b/src/app/(root)/products/[productId]/page.tsx
@@ -3,6 +3,7 @@ import {
   RecommendProductList,
   ClientProductDetail,
   ProductReview,
+  ProductDetailInfo,
 } from '@/components';
 import { setReviewSortSearchParams, setProductIdParams } from '@/utils';
 
@@ -53,9 +54,7 @@ const ProductDetailPage = async ({ params }: Params) => {
 
       <section className="gap-md flex flex-col">
         <h2 className="font-style-subHeading text-text-primary">상품 정보</h2>
-        <div className="bg-bg-secondary font-style-subHeading text-text-tertiary flex h-[640px] items-center justify-center overflow-y-auto">
-          상품정보영역
-        </div>
+        <ProductDetailInfo initialProduct={initialProduct} />
       </section>
 
       <section className="flex flex-col">

--- a/src/components/products/index.ts
+++ b/src/components/products/index.ts
@@ -13,3 +13,4 @@ export { default as CategoryProductList } from '../category/CategoryProductList'
 export { default as ClientCategoryProductList } from '../category/ClientCategoryProductList';
 export { default as ProductCategory } from '../category/ProductCategory';
 export { default as CategorySkeleton } from '../category/CategorySkeleton';
+export { default as ProductDetailInfo } from './product-detail/ProductDetailInfo';

--- a/src/components/products/product-detail/ProductDetailInfo.tsx
+++ b/src/components/products/product-detail/ProductDetailInfo.tsx
@@ -19,34 +19,34 @@ const ProductDetailInfo = ({ initialProduct }: ProductInfoTableProps) => {
 
   const tableRows = [
     {
-      label1: '스토어명',
-      value1: storeName,
-      label2: '상품상태',
-      value2: '신상품',
+      firstLabel: '스토어명',
+      firstValue: storeName,
+      secondLabel: '상품상태',
+      secondValue: '신상품',
     },
     {
-      label1: '성인인증',
-      value1: adultOnly ? '필요' : '불필요',
-      label2: '모델명',
-      value2: name,
+      firstLabel: '성인인증',
+      firstValue: adultOnly ? '필요' : '불필요',
+      secondLabel: '모델명',
+      secondValue: name,
     },
     {
-      label1: '이벤트',
-      value1: '정상배송',
-      label2: '사은품',
-      value2: '상세페이지참조',
+      firstLabel: '이벤트',
+      firstValue: '정상배송',
+      secondLabel: '사은품',
+      secondValue: '상세페이지참조',
     },
     {
-      label1: '옵션종류',
-      value1: `${productOptionItems.length}종류`,
-      label2: '출시년일',
-      value2: formatDateWithKorean(createdAt),
+      firstLabel: '옵션종류',
+      firstValue: `${productOptionItems.length}종류`,
+      secondLabel: '출시년일',
+      secondValue: formatDateWithKorean(createdAt),
     },
   ];
 
   const flattenedRows = tableRows.flatMap(row => [
-    { label: row.label1, value: row.value1 },
-    { label: row.label2, value: row.value2 },
+    { label: row.firstLabel, value: row.firstValue },
+    { label: row.secondLabel, value: row.secondValue },
   ]);
 
   return (
@@ -56,18 +56,16 @@ const ProductDetailInfo = ({ initialProduct }: ProductInfoTableProps) => {
           {tableRows.map((row, index) => (
             <tr key={index} className="hidden md:table-row">
               <td className="border-border-secondary text-text-primary bg-bg-secondary px-md py-sm w-1/6 border-y">
-                {row.label1}
+                {row.firstLabel}
               </td>
               <td className="border-border-secondary text-text-secondary px-md py-sm w-1/3 border-y">
-                {row.value1}
+                {row.firstValue}
               </td>
               <td className="border-border-secondary text-text-primary bg-bg-secondary px-md py-sm w-1/6 border-y">
-                {row.label2}
+                {row.secondLabel}
               </td>
               <td className="border-border-secondary text-text-secondary px-md py-sm w-1/3 border-y">
-                {row.value2 instanceof Date
-                  ? row.value2.toLocaleDateString('ko-KR')
-                  : row.value2}
+                {row.secondValue}
               </td>
             </tr>
           ))}
@@ -78,9 +76,7 @@ const ProductDetailInfo = ({ initialProduct }: ProductInfoTableProps) => {
                 {item.label}
               </td>
               <td className="border-border-secondary text-text-secondary px-md py-sm w-2/3 border-y">
-                {item.value instanceof Date
-                  ? item.value.toLocaleDateString('ko-KR')
-                  : item.value}
+                {item.value}
               </td>
             </tr>
           ))}

--- a/src/components/products/product-detail/ProductDetailInfo.tsx
+++ b/src/components/products/product-detail/ProductDetailInfo.tsx
@@ -1,0 +1,103 @@
+import Image from 'next/image';
+
+import { formatDateWithKorean } from '@/utils';
+import type { Product } from '@/types';
+
+interface ProductInfoTableProps {
+  initialProduct: Product;
+}
+
+const ProductDetailInfo = ({ initialProduct }: ProductInfoTableProps) => {
+  const {
+    storeName,
+    name,
+    adultOnly,
+    createdAt,
+    productOptionItems,
+    titleUrl,
+  } = initialProduct;
+
+  const tableRows = [
+    {
+      label1: '스토어명',
+      value1: storeName,
+      label2: '상품상태',
+      value2: '신상품',
+    },
+    {
+      label1: '성인인증',
+      value1: adultOnly ? '필요' : '불필요',
+      label2: '모델명',
+      value2: name,
+    },
+    {
+      label1: '이벤트',
+      value1: '정상배송',
+      label2: '사은품',
+      value2: '상세페이지참조',
+    },
+    {
+      label1: '옵션종류',
+      value1: `${productOptionItems.length}종류`,
+      label2: '출시년일',
+      value2: formatDateWithKorean(createdAt),
+    },
+  ];
+
+  const flattenedRows = tableRows.flatMap(row => [
+    { label: row.label1, value: row.value1 },
+    { label: row.label2, value: row.value2 },
+  ]);
+
+  return (
+    <div className="gap-md md:gap-4xl flex w-full flex-col">
+      <table className="border-border-secondary w-full border-collapse border-y">
+        <tbody>
+          {tableRows.map((row, index) => (
+            <tr key={index} className="hidden md:table-row">
+              <td className="border-border-secondary text-text-primary bg-bg-secondary px-md py-sm w-1/6 border-y">
+                {row.label1}
+              </td>
+              <td className="border-border-secondary text-text-secondary px-md py-sm w-1/3 border-y">
+                {row.value1}
+              </td>
+              <td className="border-border-secondary text-text-primary bg-bg-secondary px-md py-sm w-1/6 border-y">
+                {row.label2}
+              </td>
+              <td className="border-border-secondary text-text-secondary px-md py-sm w-1/3 border-y">
+                {row.value2 instanceof Date
+                  ? row.value2.toLocaleDateString('ko-KR')
+                  : row.value2}
+              </td>
+            </tr>
+          ))}
+
+          {flattenedRows.map((item, index) => (
+            <tr key={`mobile-${index}`} className="md:hidden">
+              <td className="border-border-secondary text-text-primary bg-bg-secondary px-md py-sm w-1/3 border-y">
+                {item.label}
+              </td>
+              <td className="border-border-secondary text-text-secondary px-md py-sm w-2/3 border-y">
+                {item.value instanceof Date
+                  ? item.value.toLocaleDateString('ko-KR')
+                  : item.value}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <figure className="flex justify-center">
+        <Image
+          src={titleUrl}
+          alt={name}
+          width={630}
+          height={630}
+          className="aspect-square object-cover"
+        />
+      </figure>
+    </div>
+  );
+};
+
+export default ProductDetailInfo;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -68,11 +68,10 @@ export const formatAfterDays = (dateString: string): string => {
  * @param dateString 'yyyy-mm-dd' 형식의 날짜
  * @returns 'yyyy년 mm월 dd일' 형식의 문자열
  */
-export const formatDateWithKorean = (dateString: Date) => {
+export const formatDateWithKorean = (dateString: string | Date): string => {
   if (!dateString) return '';
 
   const date = new Date(dateString);
-  if (isNaN(date.getTime())) return dateString;
 
   const year = date.getFullYear();
   const month = date.getMonth() + 1;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -62,3 +62,21 @@ export const formatAfterDays = (dateString: string): string => {
 
   return `${diffDays}일 뒤 도착 예상`;
 };
+
+/**
+ * 'yyyy-mm-dd' 형식의 날짜 문자열을 'yyyy년 mm월 dd일' 형식으로 반환하는 함수
+ * @param dateString 'yyyy-mm-dd' 형식의 날짜
+ * @returns 'yyyy년 mm월 dd일' 형식의 문자열
+ */
+export const formatDateWithKorean = (dateString: Date) => {
+  if (!dateString) return '';
+
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return dateString;
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${year}년 ${month}월 ${day}일`;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품 상세 페이지에 상세 정보에서 테이블과 이미지를 추가했어요.

## 🔧 변경 사항

- 상품 상세 테이블을 추가했어요. 상품에 대해 정보가 다양하지 않아서 일부는 하드코딩해놨어요.
- 상품 상세 이미지 필드가 따로 주어지지 않아서 썸네일 이미지 url로 이미지를 넣어놨어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
