### PR TITLE
[♻️ refactor] 비회원일 경우 장바구니에 담기는 상품 개수 제한 (#201)

### DIFF
--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -94,6 +94,21 @@ export const addToLocalCart = async (
   quantity: number,
 ) => {
   const currentCart = fetchLocalCart();
+  const MAX_CART_ITEMS_COUNT = 10;
+
+  if (currentCart.length >= MAX_CART_ITEMS_COUNT) {
+    const existingItemIndex = currentCart.findIndex(
+      cartItem => cartItem.productItemId === productItemId,
+    );
+
+    if (existingItemIndex < 0) {
+      return {
+        success: false,
+        message: `비회원은 최대 ${MAX_CART_ITEMS_COUNT}개 상품만 담을 수 있습니다.`,
+        cart: currentCart,
+      };
+    }
+  }
 
   const existingItemById = currentCart.findIndex(
     cartItem => cartItem.productItemId === productItemId,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

비회원일 경우에는 장바구니에 담기는 상품 개수를 제한했어요.
로컬스토리지에 저장하다 보니 `productId`에 일치하는 api를 여러 번 요청할 경우가 발생할 수 있어 최소한의 개수로 제한했어요.

## 🔧 변경 사항

- 비회원일 경우 장바구니에 담기는 상품 개수 10개로 제한

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/6ac17e72-1d82-41e9-aec9-35b7f06e2eaa)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
