### PR TITLE
[♻️ refactor] 비회원일 경우 결제 페이지로 이동하지 못하게 막기 (#204)

### DIFF
--- a/src/components/cart/CartInfo.tsx
+++ b/src/components/cart/CartInfo.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components';
 import CartHeader from './CartHeader';
 
-const CartInfo = () => {
+const CartInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   const router = useRouter();
   const {
     checkedCount,
@@ -37,10 +37,18 @@ const CartInfo = () => {
     JSON.stringify(payloadCheckedCartItems),
   );
 
-  const handleCheckoutClick = () =>
-    checkedCount === 0
-      ? toast.warning('주문할 상품을 선택해주세요!')
-      : router.push(ROUTER_PATH.CHECKOUT(encodedOrderProductItems));
+  const handleCheckoutClick = () => {
+    if (!isLoggedIn) {
+      toast.warning('로그인 후 이용해주세요!');
+      router.push(ROUTER_PATH.LOGIN);
+      return;
+    }
+    if (checkedCount === 0) {
+      toast.warning('주문할 상품을 선택해주세요!');
+    } else {
+      router.push(ROUTER_PATH.CHECKOUT(encodedOrderProductItems));
+    }
+  };
 
   return (
     <>

--- a/src/stories/cart/CartInfo.stories.tsx
+++ b/src/stories/cart/CartInfo.stories.tsx
@@ -31,13 +31,29 @@ type Story = StoryObj<typeof CartInfo>;
 
 export const Default: Story = {
   args: {
-    initialCartItems: mockCartItems,
+    isLoggedIn: false,
   },
+  decorators: [
+    Story => {
+      mockCartStore({
+        items: mockCartItems,
+        checkedItems: mockCartItems.reduce(
+          (acc, item) => ({
+            ...acc,
+            [item.productItemId]: true,
+          }),
+          {},
+        ),
+      });
+
+      return <Story />;
+    },
+  ],
 };
 
 export const EmptyCart: Story = {
   args: {
-    initialCartItems: [],
+    isLoggedIn: false,
   },
   decorators: [
     Story => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

비회원일 경우 결제 페이지로 이동하지 못하게 막았아요.

## 🔧 변경 사항

- 로그인 여부에 따라 결제 페이지 이동 컨트롤

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
