### PR TITLE
[✨ feat] 최신 상품에 무한 스크롤 적용 (#224)

### DIFF
--- a/src/app/api/products/latest-list/page/route.ts
+++ b/src/app/api/products/latest-list/page/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { PRODUCTS_ENDPOINTS } from '@/constants';
+import { axiosInstance } from '@/lib';
+
+export const GET = async (request: NextRequest) => {
+  try {
+    const url = new URL(request.url);
+    const cursorId = url.searchParams.get('cursorId');
+    const size = url.searchParams.get('size') || '20';
+
+    const response = await axiosInstance.get(PRODUCTS_ENDPOINTS.PAGINATION, {
+      params: {
+        cursorId: cursorId || undefined,
+        size: size,
+      },
+    });
+
+    return NextResponse.json(response.data);
+  } catch (error) {
+    return NextResponse.json(
+      { message: (error as Error).message },
+      { status: 500 },
+    );
+  }
+};

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -1,16 +1,24 @@
-import { Suspense } from 'react';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
-import ProductListSkeleton from './skeleton/ProductListSkeleton';
-import { fetchProducts } from '@/services';
+import { productServerStore } from '@/stores';
+import { productsPrefetchInfiniteQueryOptions } from '@/queries';
+import { getQueryClient } from '@/lib';
 import ClientProductList from './ClientProductList';
 
 const ProductList = async () => {
-  const initialProducts = await fetchProducts();
+  const { getParams } = productServerStore();
+  const { cursorId, size } = getParams();
+
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchInfiniteQuery(
+    productsPrefetchInfiniteQueryOptions(cursorId, size),
+  );
 
   return (
-    <Suspense fallback={<ProductListSkeleton />}>
-      <ClientProductList initialProducts={initialProducts} />
-    </Suspense>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ClientProductList />
+    </HydrationBoundary>
   );
 };
 

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -32,6 +32,7 @@ export const PRODUCTS_ENDPOINTS = {
   LATEST: `${API_RESOURCES.PRODUCTS}/latest-list`,
   DETAIL: (productId: string) => `${API_RESOURCES.PRODUCTS}/${productId}`,
   RECOMMEND: `${API_RESOURCES.PRODUCTS}/recommend`,
+  PAGINATION: `${API_RESOURCES.PRODUCTS}/latest-list/page`,
 };
 
 export const CART_ENDPOINTS = {

--- a/src/constants/queries.ts
+++ b/src/constants/queries.ts
@@ -16,6 +16,7 @@ export const PRODUCTS_QUERY_KEY = {
   LIST: 'list',
   LATEST: 'latest',
   RECOMMEND: 'recommend',
+  PAGINATION: 'pagination',
 };
 
 export const CART_QUERY_KEY = {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,6 @@
-export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { server } = await import('./lib/msw/server');
-    server.listen();
-  }
-}
+// export async function register() {
+//   if (process.env.NEXT_RUNTIME === 'nodejs') {
+//     const { server } = await import('./lib/msw/server');
+//     server.listen();
+//   }
+// }

--- a/src/lib/msw/handlers/index.ts
+++ b/src/lib/msw/handlers/index.ts
@@ -1,16 +1,16 @@
-// import { authHandlers } from './authHandlers';
-import {
-  // productsHandlers,
-  recommendedProductsHandlers,
-  // productDetailHandlers,
-} from './productsHandlers';
-// import { cartHandlers } from './cartHandlers';
-// import { orderHistoryHandlers } from './ordersHandlers';
+// // import { authHandlers } from './authHandlers';
+// import {
+//   // productsHandlers,
+//   recommendedProductsHandlers,
+//   // productDetailHandlers,
+// } from './productsHandlers';
+// // import { cartHandlers } from './cartHandlers';
+// // import { orderHistoryHandlers } from './ordersHandlers';
 
 export const handlers = [
   // ...authHandlers,
   // ...productsHandlers,
-  ...recommendedProductsHandlers,
+  //   ...recommendedProductsHandlers,
   // ...productDetailHandlers,
   // ...cartHandlers,
   // ...orderHistoryHandlers,

--- a/src/lib/msw/index.ts
+++ b/src/lib/msw/index.ts
@@ -1,6 +1,6 @@
-export const initMsw = async () => {
-  if (typeof window !== 'undefined') return;
+// export const initMsw = async () => {
+//   if (typeof window !== 'undefined') return;
 
-  const { server } = await import('./server');
-  server.listen();
-};
+//   const { server } = await import('./server');
+//   server.listen();
+// };

--- a/src/queries/productsQueries.ts
+++ b/src/queries/productsQueries.ts
@@ -1,10 +1,11 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 
 import { QUERY_KEYS_ENDPOINT, PRODUCTS_QUERY_KEY } from '@/constants';
 import {
   fetchProducts,
   fetchRecommededProducts,
   fetchProductById,
+  fetchProductsWithPagination,
 } from '@/services';
 
 export const productsQueryOptions = queryOptions({
@@ -24,5 +25,25 @@ export const productByIdQueryOptions = (productId: string) =>
     queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, productId],
     queryFn: () => fetchProductById(productId),
     staleTime: 15 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+export const productsPrefetchInfiniteQueryOptions = (
+  cursorId?: number,
+  size: number = 30,
+) => ({
+  queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.PAGINATION, size],
+  queryFn: () => fetchProductsWithPagination(cursorId, size),
+  initialPageParam: cursorId,
+});
+
+export const productsInfiniteQueryOptions = (size: number = 20) =>
+  infiniteQueryOptions({
+    queryKey: [QUERY_KEYS_ENDPOINT.PRODUCTS, PRODUCTS_QUERY_KEY.PAGINATION],
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) => fetchProductsWithPagination(pageParam, size),
+    getNextPageParam: lastPage =>
+      lastPage.hasNext ? lastPage.nextCursorId : undefined,
+    staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/lib';
 import { PRODUCTS_ENDPOINTS } from '@/constants';
-import { Product } from '@/types';
+import { Product, PaginatedProductsAPIResponse } from '@/types';
 
 export const fetchProducts = async () => {
   const response = await axiosInstance.get(PRODUCTS_ENDPOINTS.LATEST);
@@ -21,22 +21,19 @@ export const fetchProductById = async (productId: string): Promise<Product> => {
   return response.data;
 };
 
-// export const fetchProductsWithPagination = async (
-//   pageParm = 1,
-//   pageSize = 20,
-// ) => {
-//   const allProducts = await fetchProducts();
+export const fetchProductsWithPagination = async (
+  cursorId?: number,
+  size: number = 20,
+): Promise<PaginatedProductsAPIResponse> => {
+  const params: Record<string, string | number> = { size };
 
-//   const startIndex = (pageParm - 1) * pageSize;
-//   const endIndex = startIndex + pageSize;
+  if (cursorId !== undefined) {
+    params.cursorId = cursorId;
+  }
 
-//   const paginatedItems = allProducts.slice(startIndex, endIndex);
+  const response = await axiosInstance.get(PRODUCTS_ENDPOINTS.PAGINATION, {
+    params,
+  });
 
-//   const hasNextPage = endIndex < allProducts.length;
-
-//   return {
-//     items: paginatedItems,
-//     nextPage: hasNextPage ? pageParm + 1 : null,
-//     totalItems: allProducts.length,
-//   };
-// };
+  return response.data;
+};

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,3 +2,4 @@ export * from './cartStore';
 export * from './createCartMocks';
 export * from './shippingAddressStore';
 export * from './reviewServerStore';
+export * from './productServerStore';

--- a/src/stores/productServerStore.ts
+++ b/src/stores/productServerStore.ts
@@ -1,0 +1,20 @@
+import { cache } from 'react';
+
+interface ProductParams {
+  cursorId?: number;
+  size: number;
+}
+
+export const productServerStore = cache(() => {
+  const params: ProductParams = {
+    cursorId: undefined,
+    size: 30,
+  };
+
+  return {
+    getParams: () => params,
+    setParams: (newParams: Partial<ProductParams>) => {
+      Object.assign(params, newParams);
+    },
+  };
+});

--- a/src/types/productType.ts
+++ b/src/types/productType.ts
@@ -30,3 +30,10 @@ export interface Product {
   maxPurchaseQuantity: number;
   productReviewInfo?: ProductReviewInfo;
 }
+
+export interface PaginatedProductsAPIResponse {
+  hasNext: boolean;
+  nextCursorId: number | null;
+  contentSize: number;
+  content: Product[];
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

최신 상품순 상품에 무한 스크롤을 적용했어요.

## 🔧 변경 사항

- 처음에는 부모 컴포넌트에서 자식 컴포넌트로 초기 데이터를 props로 전달하는 방식을 사용했어요. 이 방식으로 무한 스크롤을 구현했을 때, 스크롤이 `threshold`를 넘은 후에야 데이터를 가져오기 시작해서 사용자 입장에서 끊김 현상이 발생했어요.
- 이 문제를 어떻게 해결할지 고민하다가 승건님이 리뷰 컴포넌트에 적용한 무한 스크롤 패턴을 참고했어요. 이 패턴은 사용자가 스크롤하기 전에 미리 데이터를 프리페칭하는 방식이었습니다.
- 이 접근법을 적용해서, 단순히 초기값을 props로 내려주는 대신 스크롤이 특정 `threshold`에 도달하기 전에 미리 다음 데이터를 서버에서 가져오도록 했어요. 이렇게 함으로써 사용자가 스크롤할 때 데이터가 이미 준비되어 있어 무한 스크롤이 훨씬 더 자연스럽게 작동하게 됐어요.
- 임의 추천 api가 제공되어 msw를 걷어냈어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

[Next.js 서버 컴포넌트와 Tanstack  Query를 활용한 무한 스크롤 성능 개선](https://www.notion.so/heymeworld/Next-js-Tanstack-Query-1c844a7e7ac580669bd1eccb64a01e0e)를 참고해주세요 !
[LCP 개선](https://www.notion.so/heymeworld/FE-1c844a7e7ac580c2b238e4e3df2b7d69) 맨 아래에 차이를 적어놨어요!
