### PR TITLE
[✨ feat] 주문 내역/상세 쿼리옵션으로 일관된 데이터와 UI 관리

### DIFF
--- a/src/app/(root)/my/orders/[orderId]/page.tsx
+++ b/src/app/(root)/my/orders/[orderId]/page.tsx
@@ -26,7 +26,7 @@ const OrderDetailPage = async ({ params }: Params) => {
   const linkItems = [
     { label: '홈', href: '' },
     { label: '마이페이지', href: '' },
-    { label: '주문 내역', href: '/orders' },
+    { label: '주문 내역', href: '/my/orders' },
     { label: pageTitle, href: `${orderId}`, isCurrent: true },
   ];
 

--- a/src/app/(root)/my/orders/[orderId]/page.tsx
+++ b/src/app/(root)/my/orders/[orderId]/page.tsx
@@ -1,8 +1,9 @@
 import { fetchOrderDetail } from '@/services';
 import { formatDateWithKorean } from '@/utils';
+import { QueryProviders } from '@/providers';
 import {
   MypageHeader,
-  OrderHistoryList,
+  OrderDetailClientWrapper,
   OrderTableInfoSection,
 } from '@/components';
 
@@ -31,24 +32,29 @@ const OrderDetailPage = async ({ params }: Params) => {
   ];
 
   return (
-    <div className="gap-4xl mx-auto flex flex-col">
-      <section className="gap-lg flex flex-col">
-        <MypageHeader linkItems={linkItems} pageName={pageTitle} />
+    <QueryProviders>
+      <div className="gap-4xl mx-auto flex flex-col">
+        <section className="gap-lg flex flex-col">
+          <MypageHeader linkItems={linkItems} pageName={pageTitle} />
 
-        <section className="gap-5xl flex flex-col">
-          <h2 className="gap-sm flex">
-            <span>{formatDateWithKorean(orderedAt)} 주문</span>
-            <span className="text-text-tertiary">주문번호 : {orderId}</span>
-          </h2>
+          <section className="gap-5xl flex flex-col">
+            <h2 className="gap-sm flex">
+              <span>{formatDateWithKorean(orderedAt)} 주문</span>
+              <span className="text-text-tertiary">주문번호 : {orderId}</span>
+            </h2>
 
-          <section className="bg-bg-tertiary px-5xl py-3xl">
-            <OrderHistoryList orderId={Number(orderId)} {...orderDetailInfo} />
+            <section className="bg-bg-tertiary px-5xl py-3xl">
+              <OrderDetailClientWrapper
+                orderId={Number(orderId)}
+                initialOrderDetailInfo={orderDetailInfo}
+              />
+            </section>
+
+            <OrderTableInfoSection {...orderDetailInfo} className="py-3xl" />
           </section>
-
-          <OrderTableInfoSection {...orderDetailInfo} className="py-3xl" />
         </section>
-      </section>
-    </div>
+      </div>
+    </QueryProviders>
   );
 };
 

--- a/src/app/(root)/my/orders/[orderId]/page.tsx
+++ b/src/app/(root)/my/orders/[orderId]/page.tsx
@@ -1,6 +1,5 @@
 import { fetchOrderDetail } from '@/services';
 import { formatDateWithKorean } from '@/utils';
-import { QueryProviders } from '@/providers';
 import {
   MypageHeader,
   OrderDetailClientWrapper,
@@ -32,29 +31,27 @@ const OrderDetailPage = async ({ params }: Params) => {
   ];
 
   return (
-    <QueryProviders>
-      <div className="gap-4xl mx-auto flex flex-col">
-        <section className="gap-lg flex flex-col">
-          <MypageHeader linkItems={linkItems} pageName={pageTitle} />
+    <div className="gap-4xl mx-auto flex flex-col">
+      <section className="gap-lg flex flex-col">
+        <MypageHeader linkItems={linkItems} pageName={pageTitle} />
 
-          <section className="gap-5xl flex flex-col">
-            <h2 className="gap-sm flex">
-              <span>{formatDateWithKorean(orderedAt)} 주문</span>
-              <span className="text-text-tertiary">주문번호 : {orderId}</span>
-            </h2>
+        <section className="gap-5xl flex flex-col">
+          <h2 className="gap-sm flex">
+            <span>{formatDateWithKorean(orderedAt)} 주문</span>
+            <span className="text-text-tertiary">주문번호 : {orderId}</span>
+          </h2>
 
-            <section className="bg-bg-tertiary px-5xl py-3xl">
-              <OrderDetailClientWrapper
-                orderId={Number(orderId)}
-                initialOrderDetailInfo={orderDetailInfo}
-              />
-            </section>
-
-            <OrderTableInfoSection {...orderDetailInfo} className="py-3xl" />
+          <section className="bg-bg-tertiary px-5xl py-3xl">
+            <OrderDetailClientWrapper
+              orderId={Number(orderId)}
+              initialOrderDetailInfo={orderDetailInfo}
+            />
           </section>
+
+          <OrderTableInfoSection {...orderDetailInfo} className="py-3xl" />
         </section>
-      </div>
-    </QueryProviders>
+      </section>
+    </div>
   );
 };
 

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -1,5 +1,6 @@
 import { fetchOrderHistoryList } from '@/services';
-import { MypageHeader, OrderHistoryListGroup } from '@/components';
+import { MypageHeader, OrderHistoryClientWrapper } from '@/components';
+import { QueryProviders } from '@/providers';
 
 const pageTitle = '주문 내역';
 
@@ -10,7 +11,7 @@ export async function generateMetadata() {
 }
 
 const OrderHistoryPage = async () => {
-  const orderHistoryList = await fetchOrderHistoryList();
+  const initialOrderHistoryList = await fetchOrderHistoryList();
 
   const linkItems = [
     { label: '홈', href: '/' },
@@ -19,12 +20,16 @@ const OrderHistoryPage = async () => {
   ];
 
   return (
-    <div className="gap-4xl mx-auto flex flex-col">
-      <section className="gap-lg flex flex-col">
-        <MypageHeader linkItems={linkItems} pageName={pageTitle} />
-        <OrderHistoryListGroup orderHistoryList={orderHistoryList} />
-      </section>
-    </div>
+    <QueryProviders>
+      <div className="gap-4xl mx-auto flex flex-col">
+        <section className="gap-lg flex flex-col">
+          <MypageHeader linkItems={linkItems} pageName={pageTitle} />
+          <OrderHistoryClientWrapper
+            initialOrderHistoryList={initialOrderHistoryList}
+          />
+        </section>
+      </div>
+    </QueryProviders>
   );
 };
 

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -13,8 +13,8 @@ const OrderHistoryPage = async () => {
   const orderHistoryList = await fetchOrderHistoryList();
 
   const linkItems = [
-    { label: '홈', href: '' },
-    { label: '마이페이지', href: '' },
+    { label: '홈', href: '/' },
+    { label: '마이페이지', href: '', isCurrent: true },
     { label: '주문내역', href: '/orders', isCurrent: true },
   ];
 

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -1,6 +1,5 @@
 import { fetchOrderHistoryList } from '@/services';
 import { MypageHeader, OrderHistoryClientWrapper } from '@/components';
-import { QueryProviders } from '@/providers';
 
 const pageTitle = '주문 내역';
 
@@ -20,16 +19,14 @@ const OrderHistoryPage = async () => {
   ];
 
   return (
-    <QueryProviders>
-      <div className="gap-4xl mx-auto flex flex-col">
-        <section className="gap-lg flex flex-col">
-          <MypageHeader linkItems={linkItems} pageName={pageTitle} />
-          <OrderHistoryClientWrapper
-            initialOrderHistoryList={initialOrderHistoryList}
-          />
-        </section>
-      </div>
-    </QueryProviders>
+    <div className="gap-4xl mx-auto flex flex-col">
+      <section className="gap-lg flex flex-col">
+        <MypageHeader linkItems={linkItems} pageName={pageTitle} />
+        <OrderHistoryClientWrapper
+          initialOrderHistoryList={initialOrderHistoryList}
+        />
+      </section>
+    </div>
   );
 };
 

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,13 +1,19 @@
 import { cn } from '@/utils';
-import type { BadgeVariant } from '@/types';
+import type { BadgeVariant, OrderStatus } from '@/types';
 
 interface BadgeProps {
   children: React.ReactNode;
   variant?: BadgeVariant;
+  orderStatus?: OrderStatus;
   className?: string;
 }
 
-const Badge = ({ children, variant = 'primary', className }: BadgeProps) => {
+const Badge = ({
+  children,
+  variant = 'primary',
+  orderStatus = 'READY',
+  className,
+}: BadgeProps) => {
   const defaultClass =
     'inline-flex justify-center items-center p-xs !w-fit h-[24px]';
   const BoldClass = `${defaultClass} rounded-full text-text-inverse`;
@@ -18,26 +24,46 @@ const Badge = ({ children, variant = 'primary', className }: BadgeProps) => {
     secondary: `${BoldClass} bg-bg-inverseBold`,
     secondaryOutline: `${OutlineClass} bg-bg-secondary text-text-secondary`,
     secondaryOutlineSquare: `${OutlineSquareClass} bg-bg-secondary text-text-secondary`,
+    secondaryOutlineSquareBorder: `${OutlineSquareClass} bg-bg-secondary text-text-secondary border-border-secondary border`,
     secondaryDot: `${DotClass} bg-bg-inverseBold`,
     primary: `${BoldClass} bg-bg-primaryInteraction`,
     primaryOutline: `${OutlineClass} bg-bg-infoSubtle text-text-info`,
     primaryOutlineSquare: `${OutlineSquareClass} bg-bg-infoSubtle text-text-info`,
+    primaryOutlineSquareBorder: `${OutlineSquareClass} bg-bg-infoSubtle text-text-info border-border-info border`,
     primaryDot: `${DotClass} bg-bg-primaryInteraction`,
     success: `${BoldClass} bg-bg-successBold`,
     successOutline: `${OutlineClass} bg-bg-successSubtle text-text-success`,
     successOutlineSquare: `${OutlineSquareClass} bg-bg-successSubtle text-text-success`,
+    successOutlineSquareBorder: `${OutlineSquareClass} bg-bg-successSubtle text-text-success border-border-success border`,
     successDot: `${DotClass} bg-bg-successBold`,
     warning: `${BoldClass} bg-bg-warningBold text-text-primary`,
     warningOutline: `${OutlineClass} bg-bg-warningSubtle text-text-warning`,
     warningOutlineSquare: `${OutlineSquareClass} bg-bg-warningSubtle text-text-warning`,
+    warningOutlineSquareBorder: `${OutlineSquareClass} bg-bg-warningSubtle text-text-warning border-border-warning border`,
     warningDot: `${DotClass} bg-bg-warningBold`,
     danger: `${BoldClass} bg-bg-dangerBold`,
     dangerOutline: `${OutlineClass} bg-bg-dangerSubtle text-text-danger`,
     dangerOutlineSquare: `${OutlineSquareClass} bg-bg-dangerSubtle text-text-danger`,
+    dangerOutlineSquareBorder: `${OutlineSquareClass} bg-bg-dangerSubtle text-text-danger border-border-danger border`,
     dangerDot: `${DotClass} bg-bg-dangerBold`,
   };
+  const orderStatusClass = {
+    READY: variantClass.warningOutlineSquareBorder,
+    DONE: variantClass.successOutlineSquareBorder,
+    CANCELED: variantClass.secondaryOutlineSquareBorder,
+  };
 
-  return <div className={cn(variantClass[variant], className)}>{children}</div>;
+  return (
+    <div
+      className={cn(
+        variantClass[variant],
+        orderStatusClass[orderStatus],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default Badge;

--- a/src/components/orders-payments/OrderHistoryList/OrderDetailClientWrapper.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderDetailClientWrapper.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchOrderDetail } from '@/services';
+import type { OrderDetailResponseAPISchema } from '@/types';
+import { OrderHistoryList } from '@/components';
+
+interface OrderDetailClientWrapperProps {
+  orderId: number;
+  initialOrderDetailInfo: OrderDetailResponseAPISchema;
+}
+
+const OrderDetailClientWrapper = ({
+  orderId,
+  initialOrderDetailInfo,
+}: OrderDetailClientWrapperProps) => {
+  const { data: orderDetailInfo } = useQuery({
+    queryKey: ['order', orderId],
+    queryFn: () => fetchOrderDetail(orderId.toString()),
+    initialData: initialOrderDetailInfo,
+  });
+
+  return (
+    <OrderHistoryList
+      orderId={orderId}
+      orderNumber={orderDetailInfo.orderNumber}
+      orderItems={orderDetailInfo.orderItems}
+      orderStatus={orderDetailInfo.orderStatus}
+    />
+  );
+};
+
+export default OrderDetailClientWrapper;

--- a/src/components/orders-payments/OrderHistoryList/OrderDetailClientWrapper.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderDetailClientWrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+
 import { fetchOrderDetail } from '@/services';
 import type { OrderDetailResponseAPISchema } from '@/types';
 import { OrderHistoryList } from '@/components';

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryClientWrapper.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryClientWrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+
 import { fetchOrderHistoryList } from '@/services';
 import type { OrderHistoryItem } from '@/types';
 import { OrderHistoryListGroup } from '@/components';

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryClientWrapper.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryClientWrapper.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchOrderHistoryList } from '@/services';
+import type { OrderHistoryItem } from '@/types';
+import { OrderHistoryListGroup } from '@/components';
+
+interface OrderHistoryClientWrapperProps {
+  initialOrderHistoryList: OrderHistoryItem[];
+}
+
+const OrderHistoryClientWrapper = ({
+  initialOrderHistoryList,
+}: OrderHistoryClientWrapperProps) => {
+  // 초기 데이터를 사용하면서 백그라운드에서 새로운 데이터 가져오기
+
+  const { data: orderHistoryList } = useQuery({
+    queryKey: ['orders'],
+    queryFn: fetchOrderHistoryList,
+    initialData: initialOrderHistoryList,
+  });
+
+  return <OrderHistoryListGroup orderHistoryList={orderHistoryList} />;
+};
+
+export default OrderHistoryClientWrapper;

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -1,4 +1,4 @@
-import { cn, formatAfterDays } from '@/utils';
+import { cn } from '@/utils';
 import type { OrderItem } from '@/types';
 import {
   ProductThumbnail,
@@ -25,7 +25,7 @@ const OrderHistoryList = ({
 }: OrderProductListProps) => {
   const itemsCount = orderItems.length;
 
-  const paddingStyles = 'px-0 py-md md:p-lg';
+  const paddingStyles = 'px-0 py-md md:py-xl';
   const thumbColumnStyles = 'w-[120px] md:w-[288px]';
   const infoColumnStyles = 'w-full md:w-full';
 
@@ -74,9 +74,7 @@ const OrderHistoryList = ({
                       className="hidden w-full items-center md:flex"
                       price={item.price}
                       quantity={item.quantity}
-                      expectedArrivalAt={formatAfterDays(
-                        item.expectedArrivalAt,
-                      )}
+                      expectedArrivalAt={item.expectedArrivalAt}
                     />
                   </div>
 
@@ -99,7 +97,7 @@ const OrderHistoryList = ({
               <ProductAmoutInfo
                 price={item.price}
                 quantity={item.quantity}
-                expectedArrivalAt={formatAfterDays(item.expectedArrivalAt)}
+                expectedArrivalAt={item.expectedArrivalAt}
                 className="justify-center"
               />
               <OrdersActions

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/utils';
 import type { OrderItem, OrderStatus } from '@/types';
 import {
@@ -87,6 +89,7 @@ const OrderHistoryList = ({
               </article>
               <div className="hidden md:flex">
                 <OrdersActions
+                  orderId={orderId}
                   itemsCount={itemsCount}
                   orderNumber={orderNumber}
                   isCanceled={orderStatus === 'CANCELED'}
@@ -103,6 +106,7 @@ const OrderHistoryList = ({
                 className="justify-center"
               />
               <OrdersActions
+                orderId={orderId}
                 itemsCount={itemsCount}
                 orderNumber={orderNumber}
                 isCanceled={orderStatus === 'CANCELED'}

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/utils';
-import type { OrderItem } from '@/types';
+import type { OrderItem, OrderStatus } from '@/types';
 import {
   ProductThumbnail,
   ProductName,
@@ -54,7 +54,7 @@ const OrderHistoryList = ({
                     'gap-2xs items-between flex flex-col',
                   )}
                 >
-                  <OrderStatusBadge orderStatus={orderStatus} />
+                  <OrderStatusBadge orderStatus={orderStatus as OrderStatus} />
 
                   <div className="gap-xs flex flex-1 flex-col">
                     <ProductName

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -81,6 +81,7 @@ const OrderHistoryList = ({
                   <OrdersExtraActions
                     orderId={orderId}
                     productItemId={item.productItemId}
+                    isCanceled={orderStatus === 'CANCELED'}
                   />
                 </div>
               </article>
@@ -88,6 +89,7 @@ const OrderHistoryList = ({
                 <OrdersActions
                   itemsCount={itemsCount}
                   orderNumber={orderNumber}
+                  isCanceled={orderStatus === 'CANCELED'}
                 />
               </div>
             </div>
@@ -103,6 +105,7 @@ const OrderHistoryList = ({
               <OrdersActions
                 itemsCount={itemsCount}
                 orderNumber={orderNumber}
+                isCanceled={orderStatus === 'CANCELED'}
               />
             </div>
           </article>

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
@@ -1,4 +1,4 @@
-import { getGroupOrderItemsByOrderId } from '@/utils';
+import { getGroupOrderItemsByOrderId, cn } from '@/utils';
 import type { OrderHistoryItem, GroupedOrderItemByOrderId } from '@/types';
 import { OrderHistoryListGroupHeader } from '@/components';
 import { default as OrderHistoryList } from './OrderHistoryList';
@@ -13,14 +13,20 @@ const OrderHistoryListGroup = ({
   const groupedOrderItems: GroupedOrderItemByOrderId[] =
     getGroupOrderItemsByOrderId(orderHistoryList);
 
+  const cancelStyles = 'rounded-md opacity-75 bg-bg-tertiary';
+
   return (
     <ul className="gap-2xl flex flex-col">
       {groupedOrderItems.map(({ orderId, orderNumber, items, orderStatus }) => (
-        <li key={orderId}>
+        <li
+          key={orderId}
+          className={cn(orderStatus === 'CANCELED' ? cancelStyles : '')}
+        >
           <article>
             <OrderHistoryListGroupHeader
               orderId={orderId}
               orderNumber={orderNumber}
+              isCanceled={orderStatus === 'CANCELED'}
             />
             <OrderHistoryList
               orderId={orderId}

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
@@ -16,7 +16,7 @@ const OrderHistoryListGroup = ({
   return (
     <ul className="gap-2xl flex flex-col">
       {groupedOrderItems.map(({ orderId, orderNumber, items, orderStatus }) => (
-        <li key={orderId} className="md:-pl-xl">
+        <li key={orderId}>
           <article>
             <OrderHistoryListGroupHeader
               orderId={orderId}

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
@@ -9,11 +9,13 @@ import { Icon, ExtraButton } from '@/components';
 interface OrderHistoryListGroupHeaderProps {
   orderId: number;
   orderNumber: string;
+  isCanceled: boolean;
 }
 
 const OrderHistoryListGroupHeader = ({
   orderId,
   orderNumber,
+  isCanceled,
 }: OrderHistoryListGroupHeaderProps) => {
   const handleCancelOrder = async () => {
     confirm('주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?');
@@ -36,7 +38,13 @@ const OrderHistoryListGroupHeader = ({
         </Link>
       </div>
 
-      <ExtraButton onClick={handleCancelOrder}>전체 주문 취소</ExtraButton>
+      {!isCanceled ? (
+        <ExtraButton onClick={handleCancelOrder}>전체 주문 취소</ExtraButton>
+      ) : (
+        <span className="text-text-disabled inline-flex items-center">
+          해당 주문이 전체 취소되었습니다
+        </span>
+      )}
     </header>
   );
 };

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-
-import { requestRefundPayment } from '@/services';
 import { ROUTER_PATH } from '@/constants';
-import type { OrderHistoryItem } from '@/types';
+import { useRefundMutation } from '@/hooks';
 import { Icon, ExtraButton } from '@/components';
 
 interface OrderHistoryListGroupHeaderProps {
@@ -19,58 +16,15 @@ const OrderHistoryListGroupHeader = ({
   orderNumber,
   isCanceled,
 }: OrderHistoryListGroupHeaderProps) => {
-  const queryClient = useQueryClient();
+  const { isPending, handleCancelOrder } = useRefundMutation();
 
-  const { mutate, isPending } = useMutation({
-    mutationFn: (data: { orderNumber: string; cancelReason: string }) =>
-      requestRefundPayment(data),
-    onMutate: async variables => {
-      // 낙관적 업데이트를 위해 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['orders'] });
+  const onCancelOrder = () => {
+    if (isPending) return;
 
-      // 현재 데이터 스냅샷 저장
-      const previousOrders = queryClient.getQueryData<OrderHistoryItem[]>([
-        'orders',
-      ]);
-
-      // 낙관적으로 상태 업데이트
-      queryClient.setQueryData<OrderHistoryItem[]>(['orders'], old => {
-        if (!old) return old;
-
-        return old.map(order => {
-          if (order.orderNumber === variables.orderNumber) {
-            // 주문 상태를 'CANCELED'로 변경
-            return { ...order, orderStatus: 'CANCELED' };
-          }
-          return order;
-        });
-      });
-
-      return { previousOrders };
-    },
-    onError: (err, variables, context) => {
-      // 오류 발생 시 이전 상태로 복구
-      if (context?.previousOrders) {
-        queryClient.setQueryData(['orders'], context.previousOrders);
-      }
-    },
-    onSettled: () => {
-      // 항상 서버와 데이터 재동기화
-      queryClient.invalidateQueries({ queryKey: ['orders'] });
-    },
-  });
-
-  const handleCancelOrder = async () => {
-    if (isPending) return; // 중복 클릭 방지
-
-    if (
-      confirm('주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?')
-    ) {
-      mutate({
-        orderNumber,
-        cancelReason: '',
-      });
-    }
+    handleCancelOrder(orderNumber, {
+      confirmMessage:
+        '주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?',
+    });
   };
 
   return (
@@ -85,7 +39,7 @@ const OrderHistoryListGroupHeader = ({
         </Link>
       </div>
       {!isCanceled ? (
-        <ExtraButton onClick={handleCancelOrder}>
+        <ExtraButton onClick={onCancelOrder}>
           {isPending ? '처리 중...' : '전체 주문 취소'}
         </ExtraButton>
       ) : (

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
@@ -6,16 +6,18 @@ import { requestRefundPayment } from '@/services';
 import { ROUTER_PATH } from '@/constants';
 import { Icon, ExtraButton } from '@/components';
 
-interface OrderHistoryListGroupProps {
+interface OrderHistoryListGroupHeaderProps {
   orderId: number;
   orderNumber: string;
 }
 
-const OrderHistoryListGroup = ({
+const OrderHistoryListGroupHeader = ({
   orderId,
   orderNumber,
-}: OrderHistoryListGroupProps) => {
+}: OrderHistoryListGroupHeaderProps) => {
   const handleCancelOrder = async () => {
+    confirm('주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?');
+
     await requestRefundPayment({
       orderNumber,
       cancelReason: '',
@@ -39,4 +41,4 @@ const OrderHistoryListGroup = ({
   );
 };
 
-export default OrderHistoryListGroup;
+export default OrderHistoryListGroupHeader;

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroupHeader.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import Link from 'next/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { requestRefundPayment } from '@/services';
 import { ROUTER_PATH } from '@/constants';
+import type { OrderHistoryItem } from '@/types';
 import { Icon, ExtraButton } from '@/components';
 
 interface OrderHistoryListGroupHeaderProps {
@@ -17,13 +19,58 @@ const OrderHistoryListGroupHeader = ({
   orderNumber,
   isCanceled,
 }: OrderHistoryListGroupHeaderProps) => {
-  const handleCancelOrder = async () => {
-    confirm('주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?');
+  const queryClient = useQueryClient();
 
-    await requestRefundPayment({
-      orderNumber,
-      cancelReason: '',
-    });
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: { orderNumber: string; cancelReason: string }) =>
+      requestRefundPayment(data),
+    onMutate: async variables => {
+      // 낙관적 업데이트를 위해 진행 중인 쿼리 취소
+      await queryClient.cancelQueries({ queryKey: ['orders'] });
+
+      // 현재 데이터 스냅샷 저장
+      const previousOrders = queryClient.getQueryData<OrderHistoryItem[]>([
+        'orders',
+      ]);
+
+      // 낙관적으로 상태 업데이트
+      queryClient.setQueryData<OrderHistoryItem[]>(['orders'], old => {
+        if (!old) return old;
+
+        return old.map(order => {
+          if (order.orderNumber === variables.orderNumber) {
+            // 주문 상태를 'CANCELED'로 변경
+            return { ...order, orderStatus: 'CANCELED' };
+          }
+          return order;
+        });
+      });
+
+      return { previousOrders };
+    },
+    onError: (err, variables, context) => {
+      // 오류 발생 시 이전 상태로 복구
+      if (context?.previousOrders) {
+        queryClient.setQueryData(['orders'], context.previousOrders);
+      }
+    },
+    onSettled: () => {
+      // 항상 서버와 데이터 재동기화
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+    },
+  });
+
+  const handleCancelOrder = async () => {
+    if (isPending) return; // 중복 클릭 방지
+
+    if (
+      confirm('주문 번호의 전체 상품 주문이 취소됩니다. 진행 하시겠습니까?')
+    ) {
+      mutate({
+        orderNumber,
+        cancelReason: '',
+      });
+    }
   };
 
   return (
@@ -37,9 +84,10 @@ const OrderHistoryListGroupHeader = ({
           주문 상세 보기 <Icon iconName="right" />
         </Link>
       </div>
-
       {!isCanceled ? (
-        <ExtraButton onClick={handleCancelOrder}>전체 주문 취소</ExtraButton>
+        <ExtraButton onClick={handleCancelOrder}>
+          {isPending ? '처리 중...' : '전체 주문 취소'}
+        </ExtraButton>
       ) : (
         <span className="text-text-disabled inline-flex items-center">
           해당 주문이 전체 취소되었습니다

--- a/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
@@ -7,12 +7,14 @@ import { Button } from '@/components';
 interface OrdersActionsProps {
   orderNumber: string;
   itemsCount: number;
+  isCanceled?: boolean;
   className?: string;
 }
 
 const OrdersActions = ({
   orderNumber,
   itemsCount,
+  isCanceled = false,
   className,
 }: OrdersActionsProps) => {
   const buttonStyles = 'h-[40px] md:h-[60px] w-full md:w-[147px]';
@@ -33,7 +35,7 @@ const OrdersActions = ({
   return (
     <article
       className={cn(
-        'gap-xs md:gap-md flex md:basis-[147px] md:flex-col',
+        'gap-xs md:gap-md md:py-xl flex md:basis-[147px] md:flex-col',
         className,
       )}
     >
@@ -45,14 +47,16 @@ const OrdersActions = ({
       >
         배송 조회
       </Button>
-      <Button
-        type="button"
-        variant="tertiaryOutline"
-        className={buttonStyles}
-        onClick={handleCancelOrder}
-      >
-        주문 취소
-      </Button>
+      {!isCanceled && (
+        <Button
+          type="button"
+          variant="tertiaryOutline"
+          className={buttonStyles}
+          onClick={handleCancelOrder}
+        >
+          주문 취소
+        </Button>
+      )}
     </article>
   );
 };

--- a/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
@@ -1,36 +1,125 @@
 'use client';
 
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { cn } from '@/utils';
 import { requestRefundPayment } from '@/services';
+import type { OrderHistoryItem, OrderDetailResponseAPISchema } from '@/types';
 import { Button } from '@/components';
 
 interface OrdersActionsProps {
+  orderId: number;
   orderNumber: string;
   itemsCount: number;
   isCanceled?: boolean;
   className?: string;
 }
 
+interface MutationContext {
+  previousOrders?: OrderHistoryItem[];
+  previousOrderDetail?: OrderDetailResponseAPISchema;
+}
+
 const OrdersActions = ({
+  orderId,
   orderNumber,
   itemsCount,
   isCanceled = false,
   className,
 }: OrdersActionsProps) => {
-  const buttonStyles = 'h-[40px] md:h-[60px] w-full md:w-[147px]';
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: { orderNumber: string; cancelReason: string }) =>
+      requestRefundPayment(data),
+    onMutate: async (variables): Promise<MutationContext> => {
+      // 진행 중인 쿼리 취소
+      await queryClient.cancelQueries({ queryKey: ['orders'] });
+      if (orderId) {
+        await queryClient.cancelQueries({ queryKey: ['order', orderId] });
+      }
+
+      // 주문 목록 스냅샷 저장
+      const previousOrders = queryClient.getQueryData<OrderHistoryItem[]>([
+        'orders',
+      ]);
+
+      // 주문 상세 스냅샷 저장 - undefined로 변경
+      const previousOrderDetail = orderId
+        ? queryClient.getQueryData<OrderDetailResponseAPISchema>([
+            'order',
+            orderId,
+          ])
+        : undefined;
+
+      // 낙관적으로 주문 목록 업데이트
+      if (previousOrders) {
+        queryClient.setQueryData<OrderHistoryItem[]>(['orders'], old => {
+          if (!old) return old;
+
+          return old.map(order => {
+            if (order.orderNumber === variables.orderNumber) {
+              return { ...order, orderStatus: 'CANCELED' };
+            }
+            return order;
+          });
+        });
+      }
+
+      // 낙관적으로 주문 상세 업데이트
+      if (previousOrderDetail && orderId) {
+        queryClient.setQueryData<OrderDetailResponseAPISchema>(
+          ['order', orderId],
+          old => {
+            if (!old) return old;
+
+            return { ...old, orderStatus: 'CANCELED' };
+          },
+        );
+      }
+
+      return { previousOrders, previousOrderDetail };
+    },
+    onError: (err, variables, context) => {
+      // 오류 발생 시 이전 상태로 복구
+      if (context?.previousOrders) {
+        queryClient.setQueryData(['orders'], context.previousOrders);
+      }
+
+      if (context?.previousOrderDetail && orderId) {
+        queryClient.setQueryData(
+          ['order', orderId],
+          context.previousOrderDetail,
+        );
+      }
+    },
+    onSettled: () => {
+      // 작업 완료 후 데이터 재검증
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      if (orderId) {
+        queryClient.invalidateQueries({ queryKey: ['order', orderId] });
+      }
+    },
+  });
 
   const handleCancelOrder = async () => {
-    if (itemsCount > 0) {
-      confirm('현재는 전체 주문 취소만 가능합니다. 진행하시겠습니까?');
+    if (isPending) return;
 
-      return;
+    if (itemsCount > 1) {
+      if (confirm('현재는 전체 주문 취소만 가능합니다. 진행하시겠습니까?')) {
+        mutate({ orderNumber, cancelReason: '' });
+      }
+    } else {
+      if (confirm('해당 상품의 주문을 취소합니다. 진행하시겠습니까?')) {
+        mutate({ orderNumber, cancelReason: '' });
+      }
     }
-
-    await requestRefundPayment({ orderNumber, cancelReason: '' });
   };
 
   const handleConfirmShipping = async () =>
     alert('지금은 배송 현황을 확인할 수 없습니다.');
+
+  const buttonStyles = 'h-[40px] md:h-[60px] w-full md:w-[147px]';
 
   return (
     <article

--- a/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-
 import { cn } from '@/utils';
-import { requestRefundPayment } from '@/services';
-import type { OrderHistoryItem, OrderDetailResponseAPISchema } from '@/types';
+import { useRefundMutation } from '@/hooks';
 import { Button } from '@/components';
 
 interface OrdersActionsProps {
@@ -15,11 +12,6 @@ interface OrdersActionsProps {
   className?: string;
 }
 
-interface MutationContext {
-  previousOrders?: OrderHistoryItem[];
-  previousOrderDetail?: OrderDetailResponseAPISchema;
-}
-
 const OrdersActions = ({
   orderId,
   orderNumber,
@@ -27,96 +19,21 @@ const OrdersActions = ({
   isCanceled = false,
   className,
 }: OrdersActionsProps) => {
-  const queryClient = useQueryClient();
+  const { isPending, handleCancelOrder } = useRefundMutation(orderId);
 
-  const { mutate, isPending } = useMutation({
-    mutationFn: (data: { orderNumber: string; cancelReason: string }) =>
-      requestRefundPayment(data),
-    onMutate: async (variables): Promise<MutationContext> => {
-      // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['orders'] });
-      if (orderId) {
-        await queryClient.cancelQueries({ queryKey: ['order', orderId] });
-      }
-
-      // 주문 목록 스냅샷 저장
-      const previousOrders = queryClient.getQueryData<OrderHistoryItem[]>([
-        'orders',
-      ]);
-
-      // 주문 상세 스냅샷 저장 - undefined로 변경
-      const previousOrderDetail = orderId
-        ? queryClient.getQueryData<OrderDetailResponseAPISchema>([
-            'order',
-            orderId,
-          ])
-        : undefined;
-
-      // 낙관적으로 주문 목록 업데이트
-      if (previousOrders) {
-        queryClient.setQueryData<OrderHistoryItem[]>(['orders'], old => {
-          if (!old) return old;
-
-          return old.map(order => {
-            if (order.orderNumber === variables.orderNumber) {
-              return { ...order, orderStatus: 'CANCELED' };
-            }
-            return order;
-          });
-        });
-      }
-
-      // 낙관적으로 주문 상세 업데이트
-      if (previousOrderDetail && orderId) {
-        queryClient.setQueryData<OrderDetailResponseAPISchema>(
-          ['order', orderId],
-          old => {
-            if (!old) return old;
-
-            return { ...old, orderStatus: 'CANCELED' };
-          },
-        );
-      }
-
-      return { previousOrders, previousOrderDetail };
-    },
-    onError: (err, variables, context) => {
-      // 오류 발생 시 이전 상태로 복구
-      if (context?.previousOrders) {
-        queryClient.setQueryData(['orders'], context.previousOrders);
-      }
-
-      if (context?.previousOrderDetail && orderId) {
-        queryClient.setQueryData(
-          ['order', orderId],
-          context.previousOrderDetail,
-        );
-      }
-    },
-    onSettled: () => {
-      // 작업 완료 후 데이터 재검증
-      queryClient.invalidateQueries({ queryKey: ['orders'] });
-      if (orderId) {
-        queryClient.invalidateQueries({ queryKey: ['order', orderId] });
-      }
-    },
-  });
-
-  const handleCancelOrder = async () => {
+  const onCancelOrder = () => {
     if (isPending) return;
 
-    if (itemsCount > 1) {
-      if (confirm('현재는 전체 주문 취소만 가능합니다. 진행하시겠습니까?')) {
-        mutate({ orderNumber, cancelReason: '' });
-      }
-    } else {
-      if (confirm('해당 상품의 주문을 취소합니다. 진행하시겠습니까?')) {
-        mutate({ orderNumber, cancelReason: '' });
-      }
-    }
+    handleCancelOrder(orderNumber, {
+      itemsCount,
+      confirmMessage:
+        itemsCount > 1
+          ? '현재는 전체 주문 취소만 가능합니다. 진행하시겠습니까?'
+          : '해당 상품의 주문을 취소합니다. 진행하시겠습니까?',
+    });
   };
 
-  const handleConfirmShipping = async () =>
+  const handleConfirmShipping = () =>
     alert('지금은 배송 현황을 확인할 수 없습니다.');
 
   const buttonStyles = 'h-[40px] md:h-[60px] w-full md:w-[147px]';
@@ -141,9 +58,9 @@ const OrdersActions = ({
           type="button"
           variant="tertiaryOutline"
           className={buttonStyles}
-          onClick={handleCancelOrder}
+          onClick={onCancelOrder}
         >
-          주문 취소
+          {isPending ? '처리 중...' : '주문 취소'}
         </Button>
       )}
     </article>

--- a/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersActions.tsx
@@ -43,7 +43,7 @@ const OrdersActions = ({
         className={buttonStyles}
         onClick={handleConfirmShipping}
       >
-        배송조회
+        배송 조회
       </Button>
       <Button
         type="button"
@@ -51,7 +51,7 @@ const OrdersActions = ({
         className={buttonStyles}
         onClick={handleCancelOrder}
       >
-        주문취소
+        주문 취소
       </Button>
     </article>
   );

--- a/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
@@ -7,11 +7,13 @@ import { ExtraButton } from '@/components';
 interface OrdersExtraActionsProps {
   orderId: number;
   productItemId: number;
+  isCanceled: boolean;
 }
 
 const OrdersExtraActions = ({
   orderId,
   productItemId,
+  isCanceled,
 }: OrdersExtraActionsProps) => {
   const handleWriteReview = () =>
     redirect(ROUTER_PATH.REVIEW_PRODUCT(orderId, productItemId));
@@ -21,9 +23,11 @@ const OrdersExtraActions = ({
       <div className="text-text-tertiary inline-flex items-center text-base">
         주문번호 : {orderId}
       </div>
-      <div className="gap-xs flex justify-end">
-        <ExtraButton onClick={handleWriteReview}>리뷰 작성</ExtraButton>
-      </div>
+      {!isCanceled && (
+        <div className="gap-xs flex justify-end">
+          <ExtraButton onClick={handleWriteReview}>리뷰 작성</ExtraButton>
+        </div>
+      )}
     </article>
   );
 };

--- a/src/components/orders-payments/OrderHistoryList/index.ts
+++ b/src/components/orders-payments/OrderHistoryList/index.ts
@@ -4,3 +4,4 @@ export { default as OrdersActions } from './OrdersActions';
 export { default as OrdersExtraActions } from './OrdersExtraActions';
 export { default as OrderHistoryListGroupHeader } from './OrderHistoryListGroupHeader';
 export { default as OrderHistoryClientWrapper } from './OrderHistoryClientWrapper';
+export { default as OrderDetailClientWrapper } from './OrderDetailClientWrapper';

--- a/src/components/orders-payments/OrderHistoryList/index.ts
+++ b/src/components/orders-payments/OrderHistoryList/index.ts
@@ -3,3 +3,4 @@ export { default as OrderHistoryListGroup } from './OrderHistoryListGroup';
 export { default as OrdersActions } from './OrdersActions';
 export { default as OrdersExtraActions } from './OrdersExtraActions';
 export { default as OrderHistoryListGroupHeader } from './OrderHistoryListGroupHeader';
+export { default as OrderHistoryClientWrapper } from './OrderHistoryClientWrapper';

--- a/src/components/orders-payments/OrderStatusBadge.tsx
+++ b/src/components/orders-payments/OrderStatusBadge.tsx
@@ -1,7 +1,5 @@
-import type { BadgeVariant } from '@/types';
+import type { BadgeVariant, OrderStatus } from '@/types';
 import { Badge } from '@/components';
-
-type OrderStatus = 'CANCELED' | 'DONE' | string;
 
 interface OrderStatusBadgeProps {
   orderStatus: OrderStatus;
@@ -14,19 +12,23 @@ interface StatusInfo {
 
 const OrderStatusBadge = ({ orderStatus }: OrderStatusBadgeProps) => {
   const status: Record<OrderStatus, StatusInfo> = {
-    CANCELED: {
-      label: '주문 취소',
-      variant: 'secondaryOutlineSquare',
+    READY: {
+      label: '결제 대기',
+      variant: 'warningOutlineSquare',
     },
     DONE: {
       label: '결제 완료',
       variant: 'successOutlineSquare',
     },
+    CANCELED: {
+      label: '주문 취소',
+      variant: 'secondaryOutlineSquare',
+    },
   };
 
   return (
-    <Badge variant={status[orderStatus]?.variant || 'primaryOutlineSquare'}>
-      {status[orderStatus]?.label || '확인 중'}
+    <Badge orderStatus={orderStatus}>
+      {status[orderStatus]?.label || orderStatus}
     </Badge>
   );
 };

--- a/src/components/orders-payments/ProductAmoutInfo.tsx
+++ b/src/components/orders-payments/ProductAmoutInfo.tsx
@@ -1,4 +1,4 @@
-import { cn, formatPrice } from '@/utils';
+import { cn, formatPrice, formatAfterDays } from '@/utils';
 
 interface ProductAmoutInfoProps {
   price: number;
@@ -22,7 +22,9 @@ const ProductAmoutInfo = ({
         {quantity} 개
       </span>
       <strong className="text-text-primaryInteraction text-base font-semibold md:text-lg">
-        {expectedArrivalAt}
+        {expectedArrivalAt
+          ? formatAfterDays(expectedArrivalAt)
+          : '배송일 알 수 없음'}
       </strong>
     </div>
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './common';
+export * from './queries';

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './useRefundMutation';

--- a/src/hooks/queries/useRefundMutation.ts
+++ b/src/hooks/queries/useRefundMutation.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { requestRefundPayment } from '@/services';
 import type { OrderHistoryItem, OrderDetailResponseAPISchema } from '@/types';
 

--- a/src/hooks/queries/useRefundMutation.ts
+++ b/src/hooks/queries/useRefundMutation.ts
@@ -1,0 +1,138 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { requestRefundPayment } from '@/services';
+import type { OrderHistoryItem, OrderDetailResponseAPISchema } from '@/types';
+
+interface CancelPaymentParams {
+  orderNumber: string;
+  cancelReason: string;
+}
+
+interface MutationContext {
+  previousOrders?: OrderHistoryItem[];
+  previousOrderDetail?: OrderDetailResponseAPISchema;
+  orderId?: number;
+}
+
+/**
+ * 결제 취소/환불 처리를 위한 커스텀 훅
+ * @param orderId 주문 ID (주문 상세 페이지에서 사용 시 필요)
+ * @returns mutation 객체 및 취소 처리 핸들러
+ */
+export const useRefundMutation = (orderId?: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: CancelPaymentParams) => requestRefundPayment(data),
+
+    onMutate: async (variables): Promise<MutationContext> => {
+      // 진행 중인 쿼리 취소
+      await queryClient.cancelQueries({ queryKey: ['orders'] });
+      if (orderId) {
+        await queryClient.cancelQueries({ queryKey: ['order', orderId] });
+      }
+
+      // 주문 목록 스냅샷 저장
+      const previousOrders = queryClient.getQueryData<OrderHistoryItem[]>([
+        'orders',
+      ]);
+
+      // 주문 상세 스냅샷 저장
+      const previousOrderDetail = orderId
+        ? queryClient.getQueryData<OrderDetailResponseAPISchema>([
+            'order',
+            orderId,
+          ])
+        : undefined;
+
+      // 낙관적으로 주문 목록 업데이트
+      if (previousOrders) {
+        queryClient.setQueryData<OrderHistoryItem[]>(['orders'], old => {
+          if (!old) return old;
+
+          return old.map(order => {
+            if (order.orderNumber === variables.orderNumber) {
+              return { ...order, orderStatus: 'CANCELED' };
+            }
+            return order;
+          });
+        });
+      }
+
+      // 낙관적으로 주문 상세 업데이트
+      if (previousOrderDetail && orderId) {
+        queryClient.setQueryData<OrderDetailResponseAPISchema>(
+          ['order', orderId],
+          old => {
+            if (!old) return old;
+
+            return { ...old, orderStatus: 'CANCELED' };
+          },
+        );
+      }
+
+      return { previousOrders, previousOrderDetail, orderId };
+    },
+
+    onError: (err, variables, context) => {
+      // 오류 발생 시 이전 상태로 복구
+      if (context?.previousOrders) {
+        queryClient.setQueryData(['orders'], context.previousOrders);
+      }
+
+      if (context?.previousOrderDetail && context.orderId) {
+        queryClient.setQueryData(
+          ['order', context.orderId],
+          context.previousOrderDetail,
+        );
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      if (orderId) {
+        queryClient.invalidateQueries({ queryKey: ['order', orderId] });
+      }
+    },
+  });
+
+  /**
+   * 주문 취소 처리 핸들러
+   * @param orderNumber 주문 번호
+   * @param options 추가 옵션 (취소 사유)
+   */
+  const handleCancelOrder = (
+    orderNumber: string,
+    options: {
+      cancelReason?: string;
+      confirmMessage?: string;
+      itemsCount?: number;
+    } = {},
+  ) => {
+    if (isPending) return;
+
+    const {
+      cancelReason = '',
+      confirmMessage = '주문을 취소하시겠습니까?',
+      itemsCount,
+    } = options;
+
+    let finalConfirmMessage = confirmMessage;
+
+    if (itemsCount && itemsCount > 1) {
+      finalConfirmMessage =
+        '현재는 전체 주문 취소만 가능합니다. 진행하시겠습니까?';
+    }
+
+    if (confirm(finalConfirmMessage)) {
+      mutate({ orderNumber, cancelReason });
+    }
+  };
+
+  return {
+    mutate,
+    isPending,
+    handleCancelOrder,
+  };
+};

--- a/src/types/ordersType.ts
+++ b/src/types/ordersType.ts
@@ -80,3 +80,5 @@ export interface OrderDetailResponseAPISchema {
   note: string;
   storeName: string;
 }
+
+export type OrderStatus = 'CANCELED' | 'DONE' | 'READY';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 주문을 취소할 경우 환불 api를 요청하는 서비스함수가 호출될 때 주문상태(orderStatus) UI가 즉각적으로 바뀌지 않아 tanstack query의 mutation을 사용했습니다. 

## 🔧 변경 사항

- 주문 내역/주문 상세 페이지에서 주문 취소 또는 전체 주문 취소 클릭 시 환불 mutation을 활용한 api 호출과  즉각적인 UI 상태 변화
- 디테일한 그리드 정렬 또는 패딩 값 수정
- 주문 취소 시 상태 UI 적용
- 공통 뱃지 컴포넌트에서 파생된 orderStatusBadge 컴포넌트 완성

## 📸 스크린샷

- 주문 내역
 
  ![image](https://github.com/user-attachments/assets/66521a04-5078-4047-ae66-cb97a66f7cf0)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
