### PR TITLE
[✨ feat] 동적 라우트를 가진 상품 상세 페이지를 SSG (#236)

### DIFF
--- a/src/app/(root)/products/[productId]/page.tsx
+++ b/src/app/(root)/products/[productId]/page.tsx
@@ -1,4 +1,8 @@
-import { fetchProductById, fetchProductReviewInfo } from '@/services';
+import {
+  fetchProductById,
+  fetchProductReviewInfo,
+  fetchProducts,
+} from '@/services';
 import {
   RecommendProductList,
   ClientProductDetail,
@@ -6,6 +10,7 @@ import {
   ProductDetailInfo,
 } from '@/components';
 import { reviewServerStore } from '@/stores';
+import type { Product } from '@/types';
 
 interface Params {
   params: Promise<{ productId: string }>;
@@ -30,13 +35,23 @@ export async function generateMetadata({ params }: Params) {
   };
 }
 
+export async function generateStaticParams() {
+  const products = await fetchProducts();
+
+  return products.map((product: Product) => ({
+    productId: String(product.productId),
+  }));
+}
+
 const ProductDetailPage = async ({ params, searchParams }: Params) => {
   const { productId } = await params;
-  const initialProduct = await fetchProductById(productId);
   const { 'review-sort': reviewSortSearchParams } = await searchParams;
+  const [initialProduct, productReviewInfo] = await Promise.all([
+    fetchProductById(productId),
+    fetchProductReviewInfo(productId),
+  ]);
+
   const { setParams } = reviewServerStore();
-  const productReviewInfo = await fetchProductReviewInfo(productId);
-  
   setParams({ productIdParams: productId, reviewSortSearchParams });
 
   return (
@@ -47,7 +62,7 @@ const ProductDetailPage = async ({ params, searchParams }: Params) => {
         productReviewInfo={productReviewInfo}
       />
 
-      <RecommendProductList categoryName="식료품" />
+      <RecommendProductList />
 
       <section className="bg-bg-secondary font-style-subHeading text-text-tertiary flex h-[640px] items-center justify-center overflow-y-auto">
         챗봇영역

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -8,6 +8,15 @@ const baseURL = isServer
   ? SERVER_API_BASE_URL
   : `${window.location.origin}/api`;
 
+export const staticAxios = axios.create({
+  baseURL: SERVER_API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+  timeout: 10000,
+});
+
 export const axiosInstance = axios.create({
   baseURL,
   headers: {

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,9 +1,9 @@
-import { axiosInstance } from '@/lib';
+import { axiosInstance, staticAxios } from '@/lib';
 import { PRODUCTS_ENDPOINTS } from '@/constants';
 import { Product } from '@/types';
 
 export const fetchProducts = async () => {
-  const response = await axiosInstance.get(PRODUCTS_ENDPOINTS.LATEST);
+  const response = await staticAxios.get(PRODUCTS_ENDPOINTS.LATEST);
 
   return response.data;
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

동적 라우트를 가진 상품 상세 페이지를 빌드 타임에서 미리 정적 페이지를 생성하도록 했어요.

## 🔧 변경 사항

- 기존 `axiosInstance`에는 `getAccessToken()`에서 `cookies()`를 request scope 내에서 작동을 해요. 
- `generateStaticParams`는 빌드 시간에 실행돼서 request scope가 없어서 접근할 수 없었어요.
- 그래서 정적 `staticAxios`를 만들었어요.
- 상품 상세 페이지에 SSG를 위한 `generateStaticParams`를 추가했어요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

[Next.js generateStaticParams 트러블슈팅: 성능 최적화를 위한 정적 페이지 생성](https://www.notion.so/heymeworld/Next-js-generateStaticParams-1c844a7e7ac580ccaa27ff25ad84506d)을 참고해주세요!
