### PR TITLE
[✨ feat] 비회원 리뷰 좋아요 시 토스트로 알림

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,10 +1,12 @@
+import { type ReactNode } from 'react';
+
 import { cn } from '@/utils';
 import Icon from './Icon';
 
-type ToastType = 'success' | 'error' | 'warning';
+type ToastType = 'success' | 'error' | 'warning' | 'linkInfo';
 
 interface ToastProps {
-  message: string;
+  message: string | ReactNode;
   type: ToastType;
 }
 
@@ -16,12 +18,14 @@ const Toast = ({ message, type = 'success' }: ToastProps) => {
     success: 'bg-bg-primaryInteraction',
     error: 'bg-bg-dangerInteraction',
     warning: 'bg-bg-warningBold',
+    linkInfo: 'border border-border-info bg-bg-primary text-text-primary',
   }[type];
 
   const Icon = {
     success: SuccessIcon,
     error: ErrorIcon,
     warning: ErrorIcon,
+    linkInfo: ErrorIcon,
   }[type];
 
   return (
@@ -34,7 +38,7 @@ const Toast = ({ message, type = 'success' }: ToastProps) => {
       <div className="flex-shrink-0">
         <Icon />
       </div>
-      <p className="font-style-paragraph flex-1">{message}</p>
+      <div className="font-style-paragraph flex-1">{message}</div>
     </div>
   );
 };

--- a/src/components/reviews/product-review/ProductReview.tsx
+++ b/src/components/reviews/product-review/ProductReview.tsx
@@ -12,9 +12,10 @@ import ReviewList from './ReviewList';
 import { getAccessToken } from '@/services';
 
 const ProductReview = async () => {
-  const isLogin = !!getAccessToken();
   const { getParams } = reviewServerStore();
   const { productIdParams, reviewSortSearchParams } = getParams();
+  const accessToken = await getAccessToken();
+  const isLogin = !!accessToken;
 
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/src/components/reviews/product-review/ReviewItem.tsx
+++ b/src/components/reviews/product-review/ReviewItem.tsx
@@ -49,7 +49,11 @@ const ReviewItem = ({ isLogin, ...review }: ReviewItemProps) => {
         >
           {reviewBadgeText}
         </ReviewBadge>
-        {isLogin && <ReviewLikeButton liked={review.liked} id={review.id} />}
+        <ReviewLikeButton
+          isLogin={isLogin}
+          liked={review.liked}
+          id={review.id}
+        />
       </div>
     </div>
   );

--- a/src/components/reviews/product-review/ReviewLikeButton.tsx
+++ b/src/components/reviews/product-review/ReviewLikeButton.tsx
@@ -4,22 +4,42 @@ import { useOptimistic, startTransition } from 'react';
 
 import { Button } from '@/components';
 import { reviewLikeAction } from '@/server-actions';
+import { toast } from '@/utils';
+import Link from 'next/link';
 
 interface ReviewLikeButtonProps {
   id: number;
   liked?: boolean;
+  isLogin: boolean;
 }
 
 const ReviewLikeButton = ({
   id,
   liked: initialLiked,
+  isLogin,
 }: ReviewLikeButtonProps) => {
   const [optimisticIsLiked, setOptimisticIsLiked] = useOptimistic(
     initialLiked || false,
     (newIsLiked: boolean) => newIsLiked,
   );
 
+  const getToastMessage = () => {
+    return (
+      <>
+        <p>로그인해주세요</p>
+        <Link className="hover:text-text-selected underline" href={'/signin'}>
+          로그인하러 가기
+        </Link>
+      </>
+    );
+  };
+
   const handleLikeClick = () => {
+    if (!isLogin) {
+      toast.linkInfo(getToastMessage());
+      return;
+    }
+
     startTransition(() => {
       setOptimisticIsLiked(!optimisticIsLiked);
 

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type ReactNode } from 'react';
 import { toast as sonnerToast } from 'sonner';
 
 import { Toast } from '@/components';
@@ -28,6 +29,15 @@ export const toast = {
   warning: (message: string, options?: Omit<ToastOptions, 'type'>) => {
     return sonnerToast.custom(
       () => <Toast message={message} type="warning" />,
+      {
+        duration: options?.duration || 3000,
+      },
+    );
+  },
+
+  linkInfo: (message: ReactNode, options?: Omit<ToastOptions, 'type'>) => {
+    return sonnerToast.custom(
+      () => <Toast message={message} type="linkInfo" />,
       {
         duration: options?.duration || 3000,
       },


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 비회원 리뷰 좋아요 시 토스트로 로그인 해야함을 알리고 로그인 페이지로 링크 제공
   - 즉시 로그인 페이지로 리다이렉션되지는 않아요!

## 🔧 변경 사항

- Toast 컴포넌트에 linkInfo를 추가했어요
- linkInfo의 경우 message props로 Link 컴포넌트를 받기 위해서 ReactNode 타입을 추가했어요

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
