### PR TITLE
[🔧 fix] 상품 상세 페이지에서 상품 구매할 때 회원 여부 판별 (#260)

### DIFF
--- a/src/components/cart/CartInfo.tsx
+++ b/src/components/cart/CartInfo.tsx
@@ -78,7 +78,7 @@ const CartInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
           <CartList />
         </section>
 
-        <section className="gap-md flex flex-col md:sticky md:top-52 md:w-1/3 md:self-start">
+        <section className="gap-md flex flex-col md:sticky md:top-36 md:w-1/3 md:self-start">
           <CartPaymentInfo
             totalPrice={totalPrice}
             discountPrice={discountPrice}

--- a/src/components/products/product-detail/ProductActions.tsx
+++ b/src/components/products/product-detail/ProductActions.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { Button } from '@/components';
-import { addCart } from '@/services';
+import { addCart, getAccessToken } from '@/services';
 import { toast } from '@/utils';
 import { ROUTER_PATH } from '@/constants';
 import { cartQueryOptions } from '@/queries';
@@ -31,10 +31,22 @@ const ProductActions = ({
 
   const noticeSelectOption = () => toast.warning('옵션을 선택해주세요!');
 
-  const handleCheckoutClick = () =>
-    disabled
-      ? noticeSelectOption()
-      : router.push(ROUTER_PATH.CHECKOUT(encodedOrderProductItems));
+  const handleCheckoutClick = async () => {
+    if (disabled) {
+      noticeSelectOption();
+      return;
+    }
+
+    const user = await getAccessToken();
+
+    if (!user) {
+      toast.warning('로그인 후 이용해주세요!');
+      router.push(ROUTER_PATH.LOGIN);
+      return;
+    }
+
+    router.push(ROUTER_PATH.CHECKOUT(encodedOrderProductItems));
+  };
 
   const handleCartClick = async () =>
     disabled ? noticeSelectOption() : await handleAddCart();


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품 상세 페이지에서 비회원일 때도 결제가 되도록 되어 있는데 회원만 가능하도록 분기 처리를 해줬어요.

## 🔧 변경 사항

- 비회원일 경우 결제 안되도록 막기

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
