### PR TITLE
[♻️ refactor] 중복되는 페이지 헤더 스타일 컴포넌트로 재사용 가능하도록 처리 및 스토리북 추가

### DIFF
--- a/src/app/(root)/cart/page.tsx
+++ b/src/app/(root)/cart/page.tsx
@@ -1,11 +1,13 @@
-import { CartInfo, RecommendProductList } from '@/components';
+
 import { getAccessToken } from '@/services';
+import { CartHeader, CartInfo, RecommendProductList } from '@/components';
 
 const CartPage = async () => {
   const isLoggedIn = !!(await getAccessToken());
 
   return (
     <div className="gap-3xl flex flex-col">
+      <CartHeader />
       <CartInfo isLoggedIn={isLoggedIn} />
       <div className="mb-7xl">
         <RecommendProductList />

--- a/src/app/(root)/cart/page.tsx
+++ b/src/app/(root)/cart/page.tsx
@@ -1,4 +1,3 @@
-
 import { getAccessToken } from '@/services';
 import { CartHeader, CartInfo, RecommendProductList } from '@/components';
 

--- a/src/app/(root)/checkout/page.tsx
+++ b/src/app/(root)/checkout/page.tsx
@@ -29,11 +29,6 @@ export async function generateMetadata({
   };
 }
 
-/**TODO
- * 인증 인가 확인 -> 인증 안되어 있으면 로그인 페이지로 이동
- * 결제 완료 시 주문 완료 페이지로 이동 -> 주문 내역을 바로 확인
- */
-
 const OrderCheckoutPage = async ({ searchParams }: OrderCheckoutPageProps) => {
   const { orderProductItems: productItemsJson } = await searchParams;
   const decodedProductItemsJson = decodeURIComponent(

--- a/src/components/cart/CartHeader.tsx
+++ b/src/components/cart/CartHeader.tsx
@@ -1,4 +1,4 @@
-import { StepProgressBar, PageTitle } from '@/components';
+import { StepProgressBar, PageTitle, PageContentHeader } from '@/components';
 import { CART_CONSTANTS } from '@/constants';
 
 const { CART, ORDER_PAYMENT, ORDER_COMPLETE } = CART_CONSTANTS;
@@ -7,16 +7,14 @@ const CartHeader = () => {
   const steps = [CART, ORDER_PAYMENT, ORDER_COMPLETE];
 
   return (
-    <header className="pt-lg md:py-5xl pb-0">
-      <div className="gap-lg md:gap-4xl flex flex-col justify-center">
+    <PageContentHeader>
         <PageTitle className="order-2 text-left md:order-1 md:text-center">
           {CART}
         </PageTitle>
         <div className="order-1 md:order-2">
           <StepProgressBar currentStep={CART} steps={steps} />
         </div>
-      </div>
-    </header>
+    </PageContentHeader>
   );
 };
 

--- a/src/components/cart/CartHeader.tsx
+++ b/src/components/cart/CartHeader.tsx
@@ -1,5 +1,5 @@
-import { StepProgressBar, PageTitle, PageContentHeader } from '@/components';
 import { CART_CONSTANTS } from '@/constants';
+import { StepProgressBar, PageTitle, PageContentHeader } from '@/components';
 
 const { CART, ORDER_PAYMENT, ORDER_COMPLETE } = CART_CONSTANTS;
 
@@ -8,12 +8,12 @@ const CartHeader = () => {
 
   return (
     <PageContentHeader>
-        <PageTitle className="order-2 text-left md:order-1 md:text-center">
-          {CART}
-        </PageTitle>
-        <div className="order-1 md:order-2">
-          <StepProgressBar currentStep={CART} steps={steps} />
-        </div>
+      <PageTitle className="order-2 text-left md:order-1 md:text-center">
+        {CART}
+      </PageTitle>
+      <div className="order-1 md:order-2">
+        <StepProgressBar currentStep={CART} steps={steps} />
+      </div>
     </PageContentHeader>
   );
 };

--- a/src/components/cart/CartInfo.tsx
+++ b/src/components/cart/CartInfo.tsx
@@ -12,7 +12,6 @@ import {
   CartPaymentInfo,
   Button,
 } from '@/components';
-import CartHeader from './CartHeader';
 
 const { CART_TOAST_MESSAGE, ALL_CHECKED, REMOVE_CHECKED, PAYMENT } =
   CART_CONSTANTS;
@@ -55,7 +54,6 @@ const CartInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
 
   return (
     <>
-      <CartHeader />
 
       <div className="gap-2xl flex flex-col md:flex-row">
         <section className="-mt-4xl md:w-2/3">

--- a/src/components/cart/CartInfo.tsx
+++ b/src/components/cart/CartInfo.tsx
@@ -53,50 +53,47 @@ const CartInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   };
 
   return (
-    <>
-
-      <div className="gap-2xl flex flex-col md:flex-row">
-        <section className="-mt-4xl md:w-2/3">
-          <div className="gap-sm flex items-center">
-            <div className="py-md flex w-full items-center justify-between">
-              <Checkbox
-                label={`${ALL_CHECKED} (${checkedCount}/${totalCount})`}
-                checked={isAllChecked}
-                onChange={checked => toggleAllCheckbox(checked)}
-                disabled={totalCount === 0}
-              />
-              <ExtraButton
-                className={cn(
-                  '!px-xs !py-2xs md:px-md md:py-xs',
-                  checkedCount === 0 && 'cursor-not-allowed',
-                )}
-                onClick={handleDeleteSelected}
-              >
-                {REMOVE_CHECKED}
-              </ExtraButton>
-            </div>
+    <div className="gap-2xl flex flex-col md:flex-row">
+      <section className="-mt-4xl md:w-2/3">
+        <div className="gap-sm flex items-center">
+          <div className="py-md flex w-full items-center justify-between">
+            <Checkbox
+              label={`${ALL_CHECKED} (${checkedCount}/${totalCount})`}
+              checked={isAllChecked}
+              onChange={checked => toggleAllCheckbox(checked)}
+              disabled={totalCount === 0}
+            />
+            <ExtraButton
+              className={cn(
+                '!px-xs !py-2xs md:px-md md:py-xs',
+                checkedCount === 0 && 'cursor-not-allowed',
+              )}
+              onClick={handleDeleteSelected}
+            >
+              {REMOVE_CHECKED}
+            </ExtraButton>
           </div>
-          <CartList />
-        </section>
+        </div>
+        <CartList />
+      </section>
 
-        <section className="gap-md flex flex-col md:sticky md:top-36 md:w-1/3 md:self-start">
-          <CartPaymentInfo
-            totalPrice={totalPrice}
-            discountPrice={discountPrice}
-            additionalPrice={additionalPrice}
-            deliveryPrice={deliveryPrice}
-            finalPrice={finalPrice}
-          />
-          <Button
-            className="font-style-heading"
-            variant={checkedCount === 0 ? 'disabled' : 'primary'}
-            onClick={handleCheckoutClick}
-          >
-            {formatPrice(finalPrice)} {PAYMENT}
-          </Button>
-        </section>
-      </div>
-    </>
+      <section className="gap-md flex flex-col md:sticky md:top-36 md:w-1/3 md:self-start">
+        <CartPaymentInfo
+          totalPrice={totalPrice}
+          discountPrice={discountPrice}
+          additionalPrice={additionalPrice}
+          deliveryPrice={deliveryPrice}
+          finalPrice={finalPrice}
+        />
+        <Button
+          className="font-style-heading"
+          variant={checkedCount === 0 ? 'disabled' : 'primary'}
+          onClick={handleCheckoutClick}
+        >
+          {formatPrice(finalPrice)} {PAYMENT}
+        </Button>
+      </section>
+    </div>
   );
 };
 

--- a/src/components/cart/index.ts
+++ b/src/components/cart/index.ts
@@ -1,4 +1,5 @@
 export { default as CartItem } from './CartItem';
 export { default as CartList } from './CartList';
 export { default as CartInfo } from './CartInfo';
+export { default as CartHeader } from './CartHeader';
 export { default as CartPaymentInfo } from './CartPaymentInfo';

--- a/src/components/common/PageContentHeader.tsx
+++ b/src/components/common/PageContentHeader.tsx
@@ -1,15 +1,19 @@
-import { cn } from "@/utils";
+import { cn } from '@/utils';
 
 interface PageContentHeaderProps {
-    children: React.ReactNode;
-    className?: string;
+  children: React.ReactNode;
+  className?: string;
 }
 
-const PageContentHeader = ({children, className}: PageContentHeaderProps) => {
-
+const PageContentHeader = ({ children, className }: PageContentHeaderProps) => {
   return (
-    <header className={cn("pt-lg md:py-5xl pb-0 gap-lg md:gap-4xl flex flex-col justify-center", className)}>
-        {children}
+    <header
+      className={cn(
+        'pt-lg md:py-5xl gap-lg md:gap-4xl flex flex-col justify-center pb-0',
+        className,
+      )}
+    >
+      {children}
     </header>
   );
 };

--- a/src/components/common/PageContentHeader.tsx
+++ b/src/components/common/PageContentHeader.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/utils";
+
+interface PageContentHeaderProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+const PageContentHeader = ({children, className}: PageContentHeaderProps) => {
+
+  return (
+    <header className={cn("pt-lg md:py-5xl pb-0 gap-lg md:gap-4xl flex flex-col justify-center", className)}>
+        {children}
+    </header>
+  );
+};
+
+export default PageContentHeader;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -22,3 +22,4 @@ export { default as Breadcrumb } from './Breadcrumb';
 export { default as NoData } from './NoData';
 export { default as ErrorPageTemplate } from './ErrorPageTemplate';
 export { default as ClickText } from './ClickText';
+export { default as PageContentHeader } from './PageContentHeader';

--- a/src/components/mypage/MypageHeader.tsx
+++ b/src/components/mypage/MypageHeader.tsx
@@ -10,11 +10,9 @@ interface MypageHeaderProps {
 const MypageHeader = ({ linkItems, pageName }: MypageHeaderProps) => {
   return (
     <PageContentHeader>
-        <Breadcrumb linkItems={linkItems} className="hidden md:block" />
-        <PageTitle className="text-left">
-          {pageName}
-        </PageTitle>
-    </PageContentHeader>  
+      <Breadcrumb linkItems={linkItems} className="hidden md:block" />
+      <PageTitle className="text-left">{pageName}</PageTitle>
+    </PageContentHeader>
   );
 };
 

--- a/src/components/mypage/MypageHeader.tsx
+++ b/src/components/mypage/MypageHeader.tsx
@@ -1,4 +1,4 @@
-import { PageTitle, Breadcrumb } from '@/components';
+import { PageTitle, Breadcrumb, PageContentHeader } from '@/components';
 interface MypageHeaderProps {
   linkItems: {
     label: string;
@@ -9,14 +9,12 @@ interface MypageHeaderProps {
 
 const MypageHeader = ({ linkItems, pageName }: MypageHeaderProps) => {
   return (
-    <header className="pt-lg md:py-5xl pb-0">
-      <div className="gap-lg justify-cente flex flex-col">
+    <PageContentHeader>
         <Breadcrumb linkItems={linkItems} className="hidden md:block" />
-        <PageTitle className="hidden text-left md:block md:text-left">
+        <PageTitle className="text-left">
           {pageName}
         </PageTitle>
-      </div>
-    </header>
+    </PageContentHeader>  
   );
 };
 

--- a/src/components/orders-payments/CheckoutHeader.tsx
+++ b/src/components/orders-payments/CheckoutHeader.tsx
@@ -8,12 +8,12 @@ const CheckoutHeader = () => {
 
   return (
     <PageContentHeader>
-        <PageTitle className="order-2 text-left md:order-1 md:text-center">
-          {ORDER_PAYMENT}
-        </PageTitle>
-        <div className="order-1 md:order-2">
-          <StepProgressBar currentStep={ORDER_PAYMENT} steps={steps} />
-        </div>
+      <PageTitle className="order-2 text-left md:order-1 md:text-center">
+        {ORDER_PAYMENT}
+      </PageTitle>
+      <div className="order-1 md:order-2">
+        <StepProgressBar currentStep={ORDER_PAYMENT} steps={steps} />
+      </div>
     </PageContentHeader>
   );
 };

--- a/src/components/orders-payments/CheckoutHeader.tsx
+++ b/src/components/orders-payments/CheckoutHeader.tsx
@@ -1,5 +1,5 @@
 import { CART_CONSTANTS } from '@/constants';
-import { StepProgressBar, PageTitle } from '@/components';
+import { StepProgressBar, PageTitle, PageContentHeader } from '@/components';
 
 const { CART, ORDER_PAYMENT, ORDER_COMPLETE } = CART_CONSTANTS;
 
@@ -7,16 +7,14 @@ const CheckoutHeader = () => {
   const steps = [CART, ORDER_PAYMENT, ORDER_COMPLETE];
 
   return (
-    <header className="pt-lg md:py-5xl pb-0">
-      <div className="gap-lg md:gap-4xl flex flex-col justify-center">
+    <PageContentHeader>
         <PageTitle className="order-2 text-left md:order-1 md:text-center">
           {ORDER_PAYMENT}
         </PageTitle>
         <div className="order-1 md:order-2">
           <StepProgressBar currentStep={ORDER_PAYMENT} steps={steps} />
         </div>
-      </div>
-    </header>
+    </PageContentHeader>
   );
 };
 

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -1,0 +1,71 @@
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PATH_NAME, ROUTER_PATH } from '@/constants';
+import { PageContentHeader, PageTitle, CartHeader, CheckoutHeader, MypageHeader } from '@/components';
+
+
+const meta = {
+    title: 'Common/PageContentHeader',
+    component: PageContentHeader,
+    parameters: {
+      layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+      children: {
+        control: 'text',
+        description: '페이지 제목 내용',
+      },
+      className: {
+        control: 'text',
+        description: '추가적인 클래스명',
+      },
+    },
+    decorators: [
+      Story => {
+        return (
+          <div className="layout-max-width">
+            <main className='px-container'>
+              <Story />
+            </main>
+          </div>
+        );
+      },
+    ],
+  } satisfies Meta<typeof PageContentHeader>;
+  
+export default meta;
+type Story = StoryObj<typeof PageContentHeader>;
+
+export const Default: Story = {
+  args: {
+    children: <PageTitle>기본 페이지 제목</PageTitle>,
+  },
+};
+
+export const CartHeaderComponent: Story = {
+    args: {},
+    render: () => <CartHeader />,
+};
+
+export const CheckoutHeaderComponent: Story = {
+    args: {},
+    render: () => <CheckoutHeader />,
+};
+
+
+const linkItems = [
+  { label: PATH_NAME.HOME, href: ROUTER_PATH.HOME },
+  { label: PATH_NAME.MY_PAGE, href: '', isCurrent: true },
+  {
+    label: PATH_NAME.ORDER_HISTORY,
+    href: ROUTER_PATH.ORDERS_HISTORY,
+    isCurrent: true,
+  },
+];
+
+export const MypageHeaderComponent: Story = {
+  args: {},
+  render: () => <MypageHeader linkItems={linkItems} pageName={PATH_NAME.ORDER_HISTORY} />
+};

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -1,40 +1,44 @@
-
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { PATH_NAME, ROUTER_PATH } from '@/constants';
-import { PageContentHeader, PageTitle, CartHeader, CheckoutHeader, MypageHeader } from '@/components';
-
+import {
+  PageContentHeader,
+  PageTitle,
+  CartHeader,
+  CheckoutHeader,
+  MypageHeader,
+} from '@/components';
 
 const meta = {
-    title: 'Common/PageContentHeader',
-    component: PageContentHeader,
-    parameters: {
-      layout: 'fullscreen',
+  title: 'Common/PageContentHeader',
+  component: PageContentHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: '페이지 제목 내용',
     },
-    tags: ['autodocs'],
-    argTypes: {
-      children: {
-        control: 'text',
-        description: '페이지 제목 내용',
-      },
-      className: {
-        control: 'text',
-        description: '추가적인 클래스명',
-      },
+    className: {
+      control: 'text',
+      description: '추가적인 클래스명',
     },
-    decorators: [
-      Story => {
-        return (
-            <div className="layout-max-width m-auto">
-              <main className='px-container'>
-                <Story />
-              </main>
-            </div>
-        );
-      },
-    ],
-  } satisfies Meta<typeof PageContentHeader>;
-  
+  },
+  decorators: [
+    Story => {
+      return (
+        <div className="layout-max-width m-auto">
+          <main className="px-container">
+            <Story />
+          </main>
+        </div>
+      );
+    },
+  ],
+} satisfies Meta<typeof PageContentHeader>;
+
 export default meta;
 type Story = StoryObj<typeof PageContentHeader>;
 
@@ -45,15 +49,14 @@ export const Default: Story = {
 };
 
 export const CartHeaderComponent: Story = {
-    args: {},
-    render: () => <CartHeader />,
+  args: {},
+  render: () => <CartHeader />,
 };
 
 export const CheckoutHeaderComponent: Story = {
-    args: {},
-    render: () => <CheckoutHeader />,
+  args: {},
+  render: () => <CheckoutHeader />,
 };
-
 
 const linkItems = [
   { label: PATH_NAME.HOME, href: ROUTER_PATH.HOME },
@@ -67,5 +70,7 @@ const linkItems = [
 
 export const MypageHeaderComponent: Story = {
   args: {},
-  render: () => <MypageHeader linkItems={linkItems} pageName={PATH_NAME.ORDER_HISTORY} />
+  render: () => (
+    <MypageHeader linkItems={linkItems} pageName={PATH_NAME.ORDER_HISTORY} />
+  ),
 };

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -25,11 +25,11 @@ const meta = {
     decorators: [
       Story => {
         return (
-          <div className="layout-max-width">
-            <main className='px-container'>
-              <Story />
-            </main>
-          </div>
+            <div className="layout-max-width m-auto">
+              <main className='px-container'>
+                <Story />
+              </main>
+            </div>
         );
       },
     ],

--- a/src/stories/common/PageTitle.stories.tsx
+++ b/src/stories/common/PageTitle.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PageTitle } from '@/components';
+
+const meta = {
+  title: 'Common/PageTitle',
+  component: PageTitle,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: '페이지 제목 내용',
+    },
+    className: {
+      control: 'text',
+      description: '추가적인 클래스명',
+    },
+  },
+} satisfies Meta<typeof PageTitle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: '페이지 제목',
+  },
+};

--- a/src/stories/common/PageTitle.stories.tsx
+++ b/src/stories/common/PageTitle.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import { PageTitle } from '@/components';
 
 const meta = {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 장바구니 페이지, 주문결제 페이지, 마이페이지 헤더에 중복되는 스타일을 컴포넌트화해서 하나로 관리하도록 PageContentHeader 컴포넌트로 리팩토링했어요
- PageTitle과 PageContentHeader 컴포넌트의 스토리를 추가했어요

## 🔧 변경 사항

- 클라이언트 컴포넌트에 위치한 CartHeader 컴포넌트를 서버컴포넌트(page)로 꺼냈어요
- PageContentHeader 컴포넌트를 만들어서 재사용했어요
- 스토리를 추가했어요

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/74540716-ecb5-4809-8584-0ca9ae6ea82e)

## 📄 기타

- 스토리북에서 레이아웃이 찌그러져 있는 부분 이슈 생성해서 수정 예정이에요
- 브레드크럼을 URL 경로에 따라 자동으로 적용되도록 수정할 예정이에요
