### PR TITLE
[⚙️ chore] 스토리북에서 레이아웃이 맞지 않는 스토리 UI 일괄 수정

### DIFF
--- a/src/stories/cart/CartInfo.stories.tsx
+++ b/src/stories/cart/CartInfo.stories.tsx
@@ -15,8 +15,10 @@ const meta: Meta<typeof CartInfo> = {
   decorators: [
     Story => {
       return (
-        <div className="max-w-7xl">
-          <Story />
+        <div className="layout-max-width py-md m-auto">
+          <main className="px-container">
+            <Story />
+          </main>
         </div>
       );
     },

--- a/src/stories/cart/CartInfo.stories.tsx
+++ b/src/stories/cart/CartInfo.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { CartInfo } from '@/components';
+import { CartInfo, CartHeader } from '@/components';
 import { mockCartStore, restoreCartStore, createMockCartItems } from '@/stores';
 
 const mockCartItems = createMockCartItems();
@@ -53,7 +53,34 @@ export const Default: Story = {
   ],
 };
 
-export const EmptyCart: Story = {
+export const WithCartHeader: Story = {
+  args: {
+    isLoggedIn: false,
+  },
+  decorators: [
+    Story => {
+      mockCartStore({
+        items: mockCartItems,
+        checkedItems: mockCartItems.reduce(
+          (acc, item) => ({
+            ...acc,
+            [item.productItemId]: true,
+          }),
+          {},
+        ),
+      });
+
+      return (
+        <>
+          <CartHeader />
+          <Story />;
+        </>
+      );
+    },
+  ],
+};
+
+export const EmptyCartWithCartHeader: Story = {
   args: {
     isLoggedIn: false,
   },
@@ -70,7 +97,12 @@ export const EmptyCart: Story = {
         isAllSelected: false,
       });
 
-      return <Story />;
+      return (
+        <>
+          <CartHeader />
+          <Story />;
+        </>
+      );
     },
   ],
 };

--- a/src/stories/cart/CartInfo.stories.tsx
+++ b/src/stories/cart/CartInfo.stories.tsx
@@ -15,8 +15,8 @@ const meta: Meta<typeof CartInfo> = {
   decorators: [
     Story => {
       return (
-        <div className="layout-max-width py-md m-auto">
-          <main className="px-container">
+        <div className="layout-max-width m-auto">
+          <main className="px-container py-md">
             <Story />
           </main>
         </div>

--- a/src/stories/cart/CartInfo.stories.tsx
+++ b/src/stories/cart/CartInfo.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof CartInfo> = {
     Story => {
       return (
         <div className="layout-max-width m-auto">
-          <main className="px-container py-md">
+          <main className="px-container py-5xl">
             <Story />
           </main>
         </div>
@@ -73,7 +73,7 @@ export const WithCartHeader: Story = {
       return (
         <>
           <CartHeader />
-          <Story />;
+          <Story />
         </>
       );
     },
@@ -100,7 +100,7 @@ export const EmptyCartWithCartHeader: Story = {
       return (
         <>
           <CartHeader />
-          <Story />;
+          <Story />
         </>
       );
     },

--- a/src/stories/orders/OrderProductListGroup.stories.tsx
+++ b/src/stories/orders/OrderProductListGroup.stories.tsx
@@ -113,8 +113,10 @@ const meta: Meta<typeof OrderProductListGroupMock> = {
   },
   decorators: [
     Story => (
-      <div className="container mx-auto p-4">
-        <Story />
+      <div className="layout-max-width py-md m-auto">
+        <main className="px-container">
+          <Story />
+        </main>
       </div>
     ),
   ],

--- a/src/stories/orders/OrderProductListGroup.stories.tsx
+++ b/src/stories/orders/OrderProductListGroup.stories.tsx
@@ -113,8 +113,8 @@ const meta: Meta<typeof OrderProductListGroupMock> = {
   },
   decorators: [
     Story => (
-      <div className="layout-max-width py-md m-auto">
-        <main className="px-container">
+      <div className="layout-max-width m-auto">
+        <main className="px-container py-md">
           <Story />
         </main>
       </div>

--- a/src/stories/pages/auth/ResetPasswordPage.stories.tsx
+++ b/src/stories/pages/auth/ResetPasswordPage.stories.tsx
@@ -6,9 +6,20 @@ const meta = {
   title: 'Pages/Auth/ResetPasswordPage',
   component: ResetPasswordPage,
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
   },
   tags: ['autodocs'],
+  decorators: [
+    Story => {
+      return (
+        <div className="relative m-auto h-screen max-w-[512px]">
+          <main className="px-container absolute top-1/2 w-full -translate-y-1/2">
+            <Story />
+          </main>
+        </div>
+      );
+    },
+  ],
 } satisfies Meta<typeof ResetPasswordPage>;
 
 export default meta;

--- a/src/stories/pages/auth/SigninPage.stories.tsx
+++ b/src/stories/pages/auth/SigninPage.stories.tsx
@@ -6,9 +6,20 @@ const meta = {
   title: 'Pages/Auth/SigninPage',
   component: SigninPage,
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
   },
   tags: ['autodocs'],
+  decorators: [
+    Story => {
+      return (
+        <div className="relative m-auto h-screen max-w-[512px]">
+          <main className="px-container absolute top-1/2 w-full -translate-y-1/2">
+            <Story />
+          </main>
+        </div>
+      );
+    },
+  ],
 } satisfies Meta<typeof SigninPage>;
 
 export default meta;

--- a/src/stories/product/ProductDetailItem.stories.tsx
+++ b/src/stories/product/ProductDetailItem.stories.tsx
@@ -11,8 +11,10 @@ const meta: Meta<typeof ProductDetailItem> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div className="max-w-7xl">
-        <Story />
+      <div className="layout-max-width py-md m-auto">
+        <main className="px-container">
+          <Story />
+        </main>
       </div>
     ),
   ],

--- a/src/stories/product/ProductDetailItem.stories.tsx
+++ b/src/stories/product/ProductDetailItem.stories.tsx
@@ -11,8 +11,8 @@ const meta: Meta<typeof ProductDetailItem> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div className="layout-max-width py-md m-auto">
-        <main className="px-container">
+      <div className="layout-max-width m-auto">
+        <main className="px-container py-md">
           <Story />
         </main>
       </div>

--- a/src/stories/product/ProductList.stories.tsx
+++ b/src/stories/product/ProductList.stories.tsx
@@ -55,8 +55,10 @@ const meta: Meta<typeof ProductListMock> = {
   },
   decorators: [
     Story => (
-      <div className="container mx-auto p-4">
-        <Story />
+      <div className="layout-max-width py-md m-auto">
+        <main className="px-container">
+          <Story />
+        </main>
       </div>
     ),
   ],

--- a/src/stories/product/ProductList.stories.tsx
+++ b/src/stories/product/ProductList.stories.tsx
@@ -55,8 +55,8 @@ const meta: Meta<typeof ProductListMock> = {
   },
   decorators: [
     Story => (
-      <div className="layout-max-width py-md m-auto">
-        <main className="px-container">
+      <div className="layout-max-width m-auto">
+        <main className="px-container py-md">
           <Story />
         </main>
       </div>

--- a/src/stories/product/RecommendProductList.stories.tsx
+++ b/src/stories/product/RecommendProductList.stories.tsx
@@ -77,8 +77,8 @@ export const Default: Story = {
 
       return (
         <QueryClientProvider client={queryClient}>
-          <div className="layout-max-width py-md m-auto">
-            <main className="px-container">
+          <div className="layout-max-width m-auto">
+            <main className="px-container py-md">
               <Story />
             </main>
           </div>

--- a/src/stories/product/RecommendProductList.stories.tsx
+++ b/src/stories/product/RecommendProductList.stories.tsx
@@ -77,8 +77,10 @@ export const Default: Story = {
 
       return (
         <QueryClientProvider client={queryClient}>
-          <div className="mx-auto max-w-7xl p-6">
-            <Story />
+          <div className="layout-max-width py-md m-auto">
+            <main className="px-container">
+              <Story />
+            </main>
           </div>
         </QueryClientProvider>
       );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 스토리에서 layout: 'centered' 로 설정되어 레이아웃이 찌그러진 UI가 풀 스크린으로 보이도록 layout: 'fullscreen' 으로 수정했어요.
- decorators 에서 레이아웃 div 요소 width 값을 현재 사이트 설정 기준으로 통일했어요.

## 🔧 변경 사항

- 스토리 들의 레이아웃을 실제 UI 화면에 맞춰서 수정했어요.
  ```tsx
  // MainLayout

  <Header isLogin={isLogin} />
    <div className="layout-max-width relative w-full flex-1">
      <main className="px-container pt-md pb-7xl md:mt-header-height mt-header-heightMobile md:pb-[100px]">
        {children}
      </main>
    </div>
  <Footer />
  ``` 
  ```tsx
  // Story
  
  const meta: Meta<typeof ProductListMock> = {
    title: 'Product/ProductList',
    component: ProductListMock,
    parameters: {
      layout: 'fullscreen',
    },
    decorators: [
      Story => (
        <div className="layout-max-width m-auto">
          <main className="px-container py-md">
            <Story />
          </main>
        </div>
      ),
    ],
  };
  ``` 

- auth 는 페이지 화면 기준 맞췄어요.
  ```tsx
  // auth Story
  
  const meta = {
    title: 'Pages/Auth/ResetPasswordPage',
    component: ResetPasswordPage,
    parameters: {
      layout: 'fullscreen',
    },
    tags: ['autodocs'],
    decorators: [
      Story => {
        return (
          <div className="relative m-auto h-screen max-w-[512px]">
            <main className="px-container absolute top-1/2 w-full -translate-y-1/2">
              <Story />
            </main>
          </div>
        );
      },
    ],
  } satisfies Meta<typeof ResetPasswordPage>;
  ``` 

## 📸 스크린샷

- 수정 전
  ![image](https://github.com/user-attachments/assets/06fdfe8c-c5a1-4127-bc3e-2eb08bd4af38)

- 수정 후 
  ![image](https://github.com/user-attachments/assets/a77d9c72-5050-49fd-bca4-aba06d8be796)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
