### PR TITLE
[✨ feat] 주문내역, 주문상세 페이지의 주문 리스트 상세페이지 연결, 리뷰작성시 productId 전달, 장바구니 추가 기능 추가

### DIFF
--- a/src/components/cart/CartItemHeader.tsx
+++ b/src/components/cart/CartItemHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 
+import { ROUTER_PATH } from '@/constants';
 import { Icon } from '../common';
 
 interface CartItemHeaderProps {
@@ -30,7 +31,7 @@ const CartItemHeader = ({
           <Link href="#">{storeName}</Link>
         </p>
 
-        <Link href={`/products/${productId}`}>
+        <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
           <h2 className="mb-xs md:mb-sm font-style-subHeading text-text-primary line-clamp-2 text-ellipsis">
             {productItemName}
           </h2>

--- a/src/components/cart/CartItemImage.tsx
+++ b/src/components/cart/CartItemImage.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 
+import { ROUTER_PATH } from '@/constants';
 import { Checkbox } from '../common';
 import { ProductThumbnail } from '../products';
 
@@ -23,7 +24,7 @@ const CartItemImage = ({
   toggleItemCheckbox,
 }: CartItemImageProps) => {
   return (
-    <figure className="relative w-1/2 md:w-2/5">
+    <article className="relative w-1/2 md:w-2/5">
       <div className="absolute top-5 left-5 z-1">
         <Checkbox
           checked={isChecked}
@@ -31,7 +32,7 @@ const CartItemImage = ({
         />
       </div>
 
-      <Link href={`/products/${productId}`}>
+      <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
         <ProductThumbnail
           height="h-auto"
           width="w-full"
@@ -40,7 +41,7 @@ const CartItemImage = ({
           className="aspect-square"
         />
       </Link>
-    </figure>
+    </article>
   );
 };
 

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import Link from 'next/link';
+
 import { cn } from '@/utils';
-import { ORDER_STATUS_LIST } from '@/constants';
+import { ORDER_STATUS_LIST, ROUTER_PATH } from '@/constants';
 import type { OrderItem, OrderStatus } from '@/types';
 import {
   ProductThumbnail,
@@ -10,8 +12,8 @@ import {
   ProductOptionInfo,
   OrdersActions,
   OrderStatusBadge,
+  OrdersExtraActions,
 } from '@/components';
-import { default as OrdersExtraActions } from './OrdersExtraActions';
 
 type OrderProductListProps = {
   orderId: number;
@@ -45,12 +47,14 @@ const OrderHistoryList = ({
             <div className="gap-4xl flex justify-between">
               <article className="gap-style-orderList flex-1">
                 <div className={THUMB_COLUMN_STYLES}>
-                  <ProductThumbnail
-                    width="w-full"
-                    className="aspect-200/175"
-                    imageUrl={item.productImgUrl}
-                    name={item.productName}
-                  />
+                  <Link href={ROUTER_PATH.PRODUCT_DETAIL(item.productId)}>
+                    <ProductThumbnail
+                      width="w-full"
+                      className="aspect-200/175"
+                      imageUrl={item.productImgUrl}
+                      name={item.productName}
+                    />
+                  </Link>
                 </div>
 
                 <div
@@ -62,10 +66,12 @@ const OrderHistoryList = ({
                   <OrderStatusBadge orderStatus={orderStatus as OrderStatus} />
 
                   <div className="gap-xs flex flex-1 flex-col">
-                    <ProductName
-                      className="w-full"
-                      productName={item.productName}
-                    />
+                    <Link href={ROUTER_PATH.PRODUCT_DETAIL(item.productId)}>
+                      <ProductName
+                        className="w-full"
+                        productName={item.productName}
+                      />
+                    </Link>
 
                     {item.firstOptionValue && (
                       <ProductOptionInfo

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -86,6 +86,7 @@ const OrderHistoryList = ({
                   <OrdersExtraActions
                     orderId={orderId}
                     orderSheetNo={orderSheetNo}
+                    productId={item.productId}
                     productItemId={item.productItemId}
                     isCanceled={orderStatus === CANCELED}
                   />

--- a/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import {
@@ -35,7 +36,9 @@ const OrdersExtraActions = ({
   return (
     <article className="w-full md:flex md:justify-between">
       <div className="text-text-tertiary inline-flex items-center text-base">
-        {ORDER_CONSTANT.ORDER_SHEET_NO} : {orderSheetNo}
+        <Link href={ROUTER_PATH.ORDERS_DETAIL(orderId)}>
+          {ORDER_CONSTANT.ORDER_SHEET_NO} : {orderSheetNo}
+        </Link>
       </div>
 
       <div className="gap-xs flex justify-end">

--- a/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
@@ -8,6 +8,7 @@ import { ExtraButton } from '@/components';
 interface OrdersExtraActionsProps {
   orderId: number;
   orderSheetNo: string;
+  productId: number;
   productItemId: number;
   isCanceled: boolean;
 }
@@ -15,11 +16,12 @@ interface OrdersExtraActionsProps {
 const OrdersExtraActions = ({
   orderId,
   orderSheetNo,
+  productId,
   productItemId,
   isCanceled,
 }: OrdersExtraActionsProps) => {
   const handleWriteReview = () =>
-    redirect(ROUTER_PATH.REVIEW_PRODUCT(orderId, productItemId));
+    redirect(ROUTER_PATH.REVIEW_PRODUCT(orderId, productId, productItemId));
 
   return (
     <article className="w-full md:flex md:justify-between">

--- a/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
@@ -2,17 +2,13 @@
 
 import { redirect } from 'next/navigation';
 
-import { useQueryClient } from '@tanstack/react-query';
-
 import {
   ROUTER_PATH,
   ORDER_CONSTANT,
   REVIEW_CONSTANTS,
   CART_CONSTANTS,
 } from '@/constants';
-import { toast } from '@/utils';
-import { addCart } from '@/services';
-import { cartQueryOptions } from '@/queries';
+import { useAddCart } from '@/hooks';
 import { ExtraButton } from '@/components';
 
 interface OrdersExtraActionsProps {
@@ -23,8 +19,6 @@ interface OrdersExtraActionsProps {
   isCanceled: boolean;
 }
 
-const { ADD_SUCCESS_MESSAGE, ADD_FAIL_MESSAGE } = CART_CONSTANTS;
-
 const OrdersExtraActions = ({
   orderId,
   orderSheetNo,
@@ -32,32 +26,11 @@ const OrdersExtraActions = ({
   productItemId,
   isCanceled,
 }: OrdersExtraActionsProps) => {
-  const queryClient = useQueryClient();
-
   const handleWriteReview = () =>
     redirect(ROUTER_PATH.REVIEW_PRODUCT(orderId, productId, productItemId));
 
-  const handleAddCart = async () => {
-    try {
-      const cartItems = [{ productItemId, quantity: 1 }];
-
-      const result = await addCart(productId, cartItems);
-
-      if (result.isSuccess) {
-        toast.success(result.message || ADD_SUCCESS_MESSAGE);
-
-        await queryClient.invalidateQueries({
-          queryKey: cartQueryOptions.queryKey,
-        });
-        await queryClient.prefetchQuery(cartQueryOptions);
-      } else {
-        toast.error(result.message || ADD_FAIL_MESSAGE);
-      }
-    } catch (error) {
-      console.error(ADD_FAIL_MESSAGE, error);
-      toast.error(ADD_FAIL_MESSAGE);
-    }
-  };
+  const cartItems = [{ productItemId, quantity: 1 }];
+  const { handleAddCart } = useAddCart(productId, cartItems);
 
   return (
     <article className="w-full md:flex md:justify-between">

--- a/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrdersExtraActions.tsx
@@ -2,7 +2,17 @@
 
 import { redirect } from 'next/navigation';
 
-import { ROUTER_PATH, ORDER_CONSTANT, REVIEW_CONSTANTS } from '@/constants';
+import { useQueryClient } from '@tanstack/react-query';
+
+import {
+  ROUTER_PATH,
+  ORDER_CONSTANT,
+  REVIEW_CONSTANTS,
+  CART_CONSTANTS,
+} from '@/constants';
+import { toast } from '@/utils';
+import { addCart } from '@/services';
+import { cartQueryOptions } from '@/queries';
 import { ExtraButton } from '@/components';
 
 interface OrdersExtraActionsProps {
@@ -13,6 +23,8 @@ interface OrdersExtraActionsProps {
   isCanceled: boolean;
 }
 
+const { ADD_SUCCESS_MESSAGE, ADD_FAIL_MESSAGE } = CART_CONSTANTS;
+
 const OrdersExtraActions = ({
   orderId,
   orderSheetNo,
@@ -20,8 +32,32 @@ const OrdersExtraActions = ({
   productItemId,
   isCanceled,
 }: OrdersExtraActionsProps) => {
+  const queryClient = useQueryClient();
+
   const handleWriteReview = () =>
     redirect(ROUTER_PATH.REVIEW_PRODUCT(orderId, productId, productItemId));
+
+  const handleAddCart = async () => {
+    try {
+      const cartItems = [{ productItemId, quantity: 1 }];
+
+      const result = await addCart(productId, cartItems);
+
+      if (result.isSuccess) {
+        toast.success(result.message || ADD_SUCCESS_MESSAGE);
+
+        await queryClient.invalidateQueries({
+          queryKey: cartQueryOptions.queryKey,
+        });
+        await queryClient.prefetchQuery(cartQueryOptions);
+      } else {
+        toast.error(result.message || ADD_FAIL_MESSAGE);
+      }
+    } catch (error) {
+      console.error(ADD_FAIL_MESSAGE, error);
+      toast.error(ADD_FAIL_MESSAGE);
+    }
+  };
 
   return (
     <article className="w-full md:flex md:justify-between">
@@ -29,13 +65,17 @@ const OrdersExtraActions = ({
         {ORDER_CONSTANT.ORDER_SHEET_NO} : {orderSheetNo}
       </div>
 
-      {!isCanceled && (
-        <div className="gap-xs flex justify-end">
+      <div className="gap-xs flex justify-end">
+        <ExtraButton onClick={handleAddCart}>
+          {CART_CONSTANTS.ADD_CART}
+        </ExtraButton>
+
+        {!isCanceled && (
           <ExtraButton onClick={handleWriteReview}>
             {REVIEW_CONSTANTS.CREATE.LABEL}
           </ExtraButton>
-        </div>
-      )}
+        )}
+      </div>
     </article>
   );
 };

--- a/src/components/products/ProductItem.tsx
+++ b/src/components/products/ProductItem.tsx
@@ -4,7 +4,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { calculateDiscountRate, formatPrice } from '@/utils';
-import { PRODUCTS_CONSTANTS, PRODUCTS_ENDPOINTS } from '@/constants';
+import {
+  PRODUCTS_CONSTANTS,
+  PRODUCTS_ENDPOINTS,
+  ROUTER_PATH,
+} from '@/constants';
 import type { Product, ProductReviewInfo } from '@/types';
 import ProductThumbnail from './ProductThumbnail';
 import { Icon } from '../common';
@@ -23,6 +27,7 @@ const ProductItem = ({
   reviewInfo,
 }: Product & { reviewInfo: ProductReviewInfo }) => {
   const router = useRouter();
+  const productDetailLink = ROUTER_PATH.PRODUCT_DETAIL(productId);
 
   const discountRate =
     originalPrice && sellingPrice
@@ -38,7 +43,7 @@ const ProductItem = ({
   return (
     <li className="gap-sm flex w-full flex-row md:flex-col md:gap-0">
       <section className="w-5/12 md:w-full">
-        <Link href={`/products/${productId}`}>
+        <Link href={productDetailLink}>
           <ProductThumbnail
             imageUrl={titleUrl}
             name={name}
@@ -70,7 +75,7 @@ const ProductItem = ({
           </div>
         </div>
 
-        <Link href={`/products/${productId}`}>
+        <Link href={productDetailLink}>
           <h2 className="font-style-subHeading line-clamp-2 w-full text-ellipsis">
             {name}
           </h2>

--- a/src/components/products/RecommendProductItem.tsx
+++ b/src/components/products/RecommendProductItem.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { ROUTER_PATH } from '@/constants';
 import { calculateDiscountRate, formatPrice } from '@/utils';
 import type { Product } from '@/types';
 import ProductThumbnail from './ProductThumbnail';
@@ -18,7 +19,7 @@ const RecommendProductItem = ({
 
   return (
     <li className="px-xs">
-      <Link href={`/products/${productId}`}>
+      <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
         <ProductThumbnail
           imageUrl={titleUrl || 'null'}
           name={name}

--- a/src/components/products/product-detail/ProductActions.tsx
+++ b/src/components/products/product-detail/ProductActions.tsx
@@ -1,13 +1,11 @@
 import { useRouter } from 'next/navigation';
 
-import { useQueryClient } from '@tanstack/react-query';
-
-import { Button } from '@/components';
-import { addCart, getAccessToken } from '@/services';
-import { toast } from '@/utils';
 import { CART_CONSTANTS, PRODUCTS_CONSTANTS, ROUTER_PATH } from '@/constants';
-import { cartQueryOptions } from '@/queries';
+import { toast } from '@/utils';
+import { useAddCart } from '@/hooks';
+import { getAccessToken } from '@/services';
 import type { SelectedOptionItem } from '@/types';
+import { Button } from '@/components';
 
 interface ProductActionsProps {
   productId: number;
@@ -17,13 +15,9 @@ interface ProductActionsProps {
   selectedOptionItems?: SelectedOptionItem[];
 }
 
-const {
-  CART_TOAST_MESSAGE,
-  ADD_SUCCESS_MESSAGE,
-  ADD_FAIL_MESSAGE,
-  ADD_CART,
-  CHECKOUT,
-} = CART_CONSTANTS;
+const { CART_TOAST_MESSAGE, ADD_CART, CHECKOUT } = CART_CONSTANTS;
+
+const BUTTON_DEFAULT_STYLE = 'font-style-subHeading flex-auto';
 
 const ProductActions = ({
   productId,
@@ -33,7 +27,6 @@ const ProductActions = ({
   selectedOptionItems = [],
 }: ProductActionsProps) => {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const mapToItems = () =>
     selectedOptionItems.length > 0
@@ -72,40 +65,20 @@ const ProductActions = ({
   const handleCartClick = async () =>
     disabled ? noticeSelectOption() : await handleAddCart();
 
-  const handleAddCart = async () => {
-    try {
-      const cartItems = mapToItems();
-
-      const result = await addCart(productId, cartItems);
-
-      if (result.isSuccess) {
-        toast.success(result.message || ADD_SUCCESS_MESSAGE);
-
-        await queryClient.invalidateQueries({
-          queryKey: cartQueryOptions.queryKey,
-        });
-        await queryClient.prefetchQuery(cartQueryOptions);
-      } else {
-        toast.error(result.message || ADD_FAIL_MESSAGE);
-      }
-    } catch (error) {
-      console.error(ADD_FAIL_MESSAGE, error);
-      toast.error(ADD_FAIL_MESSAGE);
-    }
-  };
-
-  const buttonDefaultStyle = 'font-style-subHeading flex-auto';
+  const cartItems = mapToItems();
+  const { handleAddCart } = useAddCart(productId, cartItems);
 
   return (
     <div className="gap-sm grid grid-cols-2">
       <Button
-        className={buttonDefaultStyle}
+        className={BUTTON_DEFAULT_STYLE}
         variant="secondaryOutline"
         onClick={handleCartClick}
       >
         {ADD_CART}
       </Button>
-      <Button className={buttonDefaultStyle} onClick={handleCheckoutClick}>
+
+      <Button className={BUTTON_DEFAULT_STYLE} onClick={handleCheckoutClick}>
         {CHECKOUT}
       </Button>
     </div>

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -14,6 +14,7 @@ export const ROUTER_PATH = {
   CHECKOUT_FAIL: '/checkout/fail',
   ORDERS_HISTORY: '/my/orders',
   ORDERS_DETAIL: (orderId: number) => `/my/orders/${orderId}`,
+  PRODUCT_DETAIL: (productId: number) => `/products/${productId}`,
   PRODUCT_CATEGORY: (categoryId: string) => `/products?category=${categoryId}`,
   REVIEW_PRODUCT: (orderId: number, productId: number, productItemId: number) =>
     `/my/review/write/${orderId}/${productId}/${productItemId}`,

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -15,8 +15,8 @@ export const ROUTER_PATH = {
   ORDERS_HISTORY: '/my/orders',
   ORDERS_DETAIL: (orderId: number) => `/my/orders/${orderId}`,
   PRODUCT_CATEGORY: (categoryId: string) => `/products?category=${categoryId}`,
-  REVIEW_PRODUCT: (orderId: number, productItemId: number) =>
-    `/my/review/write/${orderId}/${productItemId}`,
+  REVIEW_PRODUCT: (orderId: number, productId: number, productItemId: number) =>
+    `/my/review/write/${orderId}/${productId}/${productItemId}`,
   ERROR_AUTHORIZED: '/error/authorized',
   ERROR_UNAUTHORIZED: '/error/unauthorized',
   ERROR_RESTRICTED: '/error/restricted',

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,5 +1,6 @@
 export * from './useDebounce';
 export * from './useCart';
+export { useAddCart } from './useAddCart';
 export * from './useProductListVirtualizer';
 export * from './useProductReviews';
 export * from './useProductOptions';

--- a/src/hooks/common/useAddCart.ts
+++ b/src/hooks/common/useAddCart.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { CART_CONSTANTS } from '@/constants';
+import { toast } from '@/utils';
+import { addCart } from '@/services';
+import { cartQueryOptions } from '@/queries';
+import type { CartItem } from '@/types';
+
+const { ADD_SUCCESS_MESSAGE, ADD_FAIL_MESSAGE } = CART_CONSTANTS;
+
+const useAddCart = (productId: number, cartItems: CartItem[]) => {
+  const queryClient = useQueryClient();
+
+  const handleAddCart = async () => {
+    try {
+      const result = await addCart(productId, cartItems);
+
+      if (result.isSuccess) {
+        toast.success(result.message || ADD_SUCCESS_MESSAGE);
+
+        await queryClient.invalidateQueries({
+          queryKey: cartQueryOptions.queryKey,
+        });
+        await queryClient.prefetchQuery(cartQueryOptions);
+      } else {
+        toast.error(result.message || ADD_FAIL_MESSAGE);
+      }
+    } catch (error) {
+      console.error(ADD_FAIL_MESSAGE, error);
+      toast.error(ADD_FAIL_MESSAGE);
+    }
+  };
+
+  return {
+    handleAddCart,
+  };
+};
+
+export { useAddCart };

--- a/src/stories/orders/OrderProductListGroup.stories.tsx
+++ b/src/stories/orders/OrderProductListGroup.stories.tsx
@@ -20,6 +20,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 5,
     storeName: '라이프스타일 트렌드',
+    productId: 1,
     productItemId: 11,
     productName: '풀커버 강화유리 액정보호필름 갤럭시노트20, 2매입',
     productImgUrl: sampleImage,
@@ -34,6 +35,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 9,
     storeName: '꼼꼼이몰',
+    productId: 2,
     productItemId: 22,
     productName: '캐논 G3910 정품 무한잉크',
     productImgUrl: sampleImage,
@@ -48,6 +50,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 4,
     storeName: '홈 & 테크 쇼핑몰',
+    productId: 3,
     productItemId: 8,
     productName:
       '케이스 카드 2장 포켓 수납 파스텔 카메라 풀커버 실리콘 젤리 라벤더, 갤럭시S25 플러스',
@@ -63,6 +66,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 3,
     storeName: 'Marshall 공식몰',
+    productId: 4,
     productItemId: 320,
     productName: '[본사최신제품]인셀덤 크림 엑티브 50ml EX 수분 이엑스',
     productImgUrl: sampleImage,
@@ -77,6 +81,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 4,
     storeName: '홈 & 테크 쇼핑몰',
+    productId: 5,
     productItemId: 447,
     productName: '프로쉬 알로에베라 고농축 세탁세제 3L',
     productImgUrl: sampleImage,
@@ -91,6 +96,7 @@ const createOrderItems = (): OrderItem[] => [
   {
     storeId: 7,
     storeName: '살림의여왕',
+    productId: 6,
     productItemId: 370,
     productName:
       '르네 디종 프렌치 머스타드 850g 식자재 식료품 가공식품 수입식품 수입식재료',

--- a/src/types/ordersType.ts
+++ b/src/types/ordersType.ts
@@ -8,8 +8,9 @@ export interface OrderProductItem {
 export interface OrderItem {
   storeId: number;
   storeName: string;
-  productItemId: number;
+  productId: number;
   productName: string;
+  productItemId: number;
   productImgUrl: string;
   firstOptionName: string | null;
   firstOptionValue: string | null;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

`/orders`, `/orders/{orderId}` 응답 값에 `productId`, `orderId`가 추가되어 기존에 구현하지 못한 기능들을 구현했어요
- 주문 리스트 항목 별 상품 마다 상품 상세 페이지 연결
- 주문 리스트 항목 별 상품 리뷰 작성 시 `productId` 추가 전달
- 주문 리스트 항목 별 상품 장바구니 추가 버튼 추가 및 훅 생성

## 🔧 변경 사항

- 상품상세 페이지 링크를 연결하면서 상세페이지 링크를 상수화하여 리팩토링 했어요
- 리뷰 작성 시 전달하는 패스파라미터에 `productId`를 추가했어요
- 주문 내역, 상세 페이지에서 확인하는 상품들을 바로 추가 가능하도록 장바구니 당기 기능을 추가했어요. 여기서 상세페이지의 장바구니 담기 함수 코드 중복이 생겨서 장바구니 담는 기능을 하는 useAddCart 커스텀훅을 만들었어요. 


## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

- 주문 내역에서 장바구니를 추가할 때 수량을 주문했던 그대로 담아야하는지 UX적으로 고민하다가 수량은 1개만 추가하고 장바구니에서 수량을 조절하는 유저플로우를 고려했어요. 어떤게 더 사용자의 경험이 좋을 수 있을까요?
