### PR TITLE
[✨ feat] 상품 검색 api 연동 및 페이지 구현 (#312)

### DIFF
--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -15,8 +15,6 @@ type SearchParamsProps = {
   }>;
 };
 
-const CONATINER_CLASSNAME = 'gap-md md:gap-4xl flex flex-col';
-
 const ProductPage = async ({ searchParams }: SearchParamsProps) => {
   const params = await searchParams;
   const categoryId = params.category || '1';
@@ -35,28 +33,27 @@ const ProductPage = async ({ searchParams }: SearchParamsProps) => {
   const categoryName = selectedCategory.name;
 
   return (
-    <>
+    <div className="gap-md md:gap-4xl flex flex-col">
       {searchWord ? (
-        <div className={CONATINER_CLASSNAME}>
+        <>
           <h1 className="font-style-title text-center">
             {PRODUCTS_CONSTANTS.SEARCH_RESULT(searchWord)}
           </h1>
-
           <ProductCategory />
           <RecommendProductList />
           <SearchResultList searchWord={searchWord} />
-        </div>
+        </>
       ) : (
-        <div className={CONATINER_CLASSNAME}>
+        <>
           <ProductCategory
             initialCategories={categories}
             currentCategoryId={categoryId}
           />
           <RecommendProductList categoryName={categoryName} />
           <CategoryProductList categoryId={categoryId} />
-        </div>
+        </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -15,6 +15,8 @@ type SearchParamsProps = {
   }>;
 };
 
+const CONATINER_CLASSNAME = 'gap-md md:gap-4xl flex flex-col';
+
 const ProductPage = async ({ searchParams }: SearchParamsProps) => {
   const params = await searchParams;
   const categoryId = params.category || '1';
@@ -35,7 +37,7 @@ const ProductPage = async ({ searchParams }: SearchParamsProps) => {
   return (
     <>
       {searchWord ? (
-        <div className="gap-md md:gap-4xl flex flex-col">
+        <div className={CONATINER_CLASSNAME}>
           <h1 className="font-style-title text-center">
             {PRODUCTS_CONSTANTS.SEARCH_RESULT(searchWord)}
           </h1>
@@ -45,7 +47,7 @@ const ProductPage = async ({ searchParams }: SearchParamsProps) => {
           <SearchResultList searchWord={searchWord} />
         </div>
       ) : (
-        <div className="gap-md md:gap-4xl flex flex-col">
+        <div className={CONATINER_CLASSNAME}>
           <ProductCategory
             initialCategories={categories}
             currentCategoryId={categoryId}

--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -2,18 +2,23 @@ import {
   ProductCategory,
   CategoryProductList,
   RecommendProductList,
+  SearchResultList,
 } from '@/components';
+import { PRODUCTS_CONSTANTS } from '@/constants';
 import { fetchCategories } from '@/services';
 import type { CategoryResponseAPISchema } from '@/types';
 
 type SearchParamsProps = {
   searchParams: Promise<{
     category?: string;
+    'search-word'?: string;
   }>;
 };
 
 const ProductPage = async ({ searchParams }: SearchParamsProps) => {
-  const categoryId = (await searchParams).category || '1';
+  const params = await searchParams;
+  const categoryId = params.category || '1';
+  const searchWord = params['search-word'] || '';
 
   const categories = await fetchCategories();
   const selectedCategory = categories
@@ -29,14 +34,26 @@ const ProductPage = async ({ searchParams }: SearchParamsProps) => {
 
   return (
     <>
-      <div className="gap-md md:gap-4xl flex flex-col">
-        <ProductCategory
-          initialCategories={categories}
-          currentCategoryId={categoryId}
-        />
-        <RecommendProductList categoryName={categoryName} />
-        <CategoryProductList categoryId={categoryId} />
-      </div>
+      {searchWord ? (
+        <div className="gap-md md:gap-4xl flex flex-col">
+          <h1 className="font-style-title text-center">
+            {PRODUCTS_CONSTANTS.SEARCH_RESULT(searchWord)}
+          </h1>
+
+          <ProductCategory />
+          <RecommendProductList />
+          <SearchResultList searchWord={searchWord} />
+        </div>
+      ) : (
+        <div className="gap-md md:gap-4xl flex flex-col">
+          <ProductCategory
+            initialCategories={categories}
+            currentCategoryId={categoryId}
+          />
+          <RecommendProductList categoryName={categoryName} />
+          <CategoryProductList categoryId={categoryId} />
+        </div>
+      )}
     </>
   );
 };

--- a/src/app/api/products/search-list/route.ts
+++ b/src/app/api/products/search-list/route.ts
@@ -1,25 +1,31 @@
 import { NextResponse } from 'next/server';
 
-import { axiosInstance } from '@/lib';
-import { PRODUCT_API_ROUTE_MESSAGE, PRODUCTS_ENDPOINTS } from '@/constants';
+import { PRODUCT_API_ROUTE_MESSAGE } from '@/constants';
+import { fetchSearchProductsWithPagination } from '@/services';
 
 export const POST = async (request: Request) => {
   try {
     const body = await request.json();
     const { keyword, cursorId, size } = body;
 
-    const response = await axiosInstance.post(PRODUCTS_ENDPOINTS.SEARCH, {
-      keyword: keyword || '',
-      cursorId: cursorId || null,
-      size: size || 20,
-    });
+    const response = await fetchSearchProductsWithPagination(
+      keyword || '',
+      cursorId || null,
+      size || 20,
+    );
 
-    return NextResponse.json(response.data);
+    return NextResponse.json(response);
   } catch (error) {
     console.error(PRODUCT_API_ROUTE_MESSAGE.SEARCH_PRODUCT_ERROR, error);
+
+    const status =
+      error instanceof Error && 'status' in error
+        ? (error.status as number)
+        : 500;
+
     return NextResponse.json(
-      { message: PRODUCT_API_ROUTE_MESSAGE.SEARCH_PRODUCT_ERROR },
-      { status: 500 },
+      { message: (error as Error).message },
+      { status: status },
     );
   }
 };

--- a/src/app/api/products/search-list/route.ts
+++ b/src/app/api/products/search-list/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+import { axiosInstance } from '@/lib';
+import { PRODUCT_API_ROUTE_MESSAGE, PRODUCTS_ENDPOINTS } from '@/constants';
+
+export const POST = async (request: Request) => {
+  try {
+    const body = await request.json();
+    const { keyword, cursorId, size } = body;
+
+    const response = await axiosInstance.post(PRODUCTS_ENDPOINTS.SEARCH, {
+      keyword: keyword || '',
+      cursorId: cursorId || null,
+      size: size || 20,
+    });
+
+    return NextResponse.json(response.data);
+  } catch (error) {
+    console.error(PRODUCT_API_ROUTE_MESSAGE.SEARCH_PRODUCT_ERROR, error);
+    return NextResponse.json(
+      { message: PRODUCT_API_ROUTE_MESSAGE.SEARCH_PRODUCT_ERROR },
+      { status: 500 },
+    );
+  }
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,4 @@ export * from './checkout';
 export * from './orders-payments';
 export * from './mypage';
 export * from './main';
+export * from './search';

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import { ROUTER_PATH } from '@/constants';
-import { SearchInput, Logo, NavIcon } from '@/components';
+import { SearchInput, Logo, NavIcon, Button } from '@/components';
 import HeaderNavigation from './HeaderNavigation';
 import TextHeader from './TextHeader';
 
@@ -17,17 +17,16 @@ const Header = ({ isLogin }: HeaderProps) => {
 
   const toggleSearch = () => {
     setIsSearchOpen(!isSearchOpen);
-    console.log('isSearchOpen', isSearchOpen);
   };
 
   return (
-    <header className="bg-bg-primary pt-sm md:pb-md md:border-border-secondary fixed top-0 right-0 left-0 z-10 w-full md:border-b">
+    <header className="bg-bg-primary py-sm md:pb-md md:border-border-secondary fixed top-0 right-0 left-0 z-10 w-full md:border-b">
       <div className="px-container gap-xs layout-max-width mx-auto flex w-full flex-col">
         <nav className="ml-auto hidden md:block">
           <TextHeader isLogin={isLogin} country="한국" />
         </nav>
 
-        <div className="gap-lg flex h-[54px] items-center justify-between md:h-[64px]">
+        <div className="gap-lg flex items-center justify-between">
           <Link href={ROUTER_PATH.HOME}>
             <Logo />
           </Link>
@@ -35,8 +34,19 @@ const Header = ({ isLogin }: HeaderProps) => {
             <SearchInput />
           </div>
           {isSearchOpen && (
-            <div className="bg-bg-primary absolute right-[var(--space-container)] left-[var(--space-container)] h-[64px] w-[calc(100%-2*var(--space-container))] md:hidden">
-              <SearchInput />
+            <div className="bg-bg-primary absolute right-[var(--space-container)] left-[var(--space-container)] w-[calc(100%-2*var(--space-container))] md:hidden">
+              <div className="gap-xs flex items-center">
+                <div className="flex-1">
+                  <SearchInput />
+                </div>
+                <Button
+                  className="px-sm py-xs rounded-xl"
+                  variant="primaryOutline"
+                  onClick={toggleSearch}
+                >
+                  닫기
+                </Button>
+              </div>
             </div>
           )}
           <div className="md:gap-xl gap-md flex">

--- a/src/components/layout/header/SearchInput.tsx
+++ b/src/components/layout/header/SearchInput.tsx
@@ -54,7 +54,7 @@ const SearchInput = ({
       </div>
 
       <form
-        className="px-2xl py-xs relative flex items-center justify-between"
+        className="px-lg md:px-2xl py-xs relative flex items-center justify-between"
         onSubmit={handleSubmit}
       >
         <input
@@ -66,7 +66,7 @@ const SearchInput = ({
         />
 
         <button className="cursor-pointer" aria-label="search">
-          <SearchIcon />
+          <SearchIcon className="h-6 w-6 md:h-auto md:w-auto" />
         </button>
       </form>
     </div>

--- a/src/components/layout/header/SearchInput.tsx
+++ b/src/components/layout/header/SearchInput.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { SearchIcon } from '@/components';
 import { useDebounce } from '@/hooks';
 import { cn } from '@/utils';
+import { PRODUCTS_CONSTANTS, PRODUCTS_ENDPOINTS } from '@/constants';
 
 interface SearchInputProps {
   placeholder?: string;
@@ -15,12 +17,13 @@ interface SearchInputProps {
 }
 
 const SearchInput = ({
-  placeholder = '현재 찾고 싶은 상품을 검색해주세요!',
+  placeholder = PRODUCTS_CONSTANTS.SEARCH_PLACEHOLDER,
   onChange,
   value,
   className = '',
   debounceTime = 300,
 }: SearchInputProps) => {
+  const router = useRouter();
   const [inputValue, setInputValue] = useState(value || '');
 
   const debouncedValue = useDebounce(inputValue, debounceTime);
@@ -37,6 +40,10 @@ const SearchInput = ({
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (inputValue.trim()) {
+      router.push(PRODUCTS_ENDPOINTS.SEARCH_PAGE(inputValue.trim()));
+    }
     setInputValue('');
   };
 

--- a/src/components/search/ClientSearchResultList.tsx
+++ b/src/components/search/ClientSearchResultList.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { searchProductsInfiniteQueryOptions } from '@/queries';
+import { useProductListVirtualizer, useProductReviews } from '@/hooks';
+import { PRODUCTS_CONSTANTS } from '@/constants';
+import type { Product, ProductReviewInfo } from '@/types';
+import { ProductItem, ProductListSkeleton } from '../products';
+import { NoData } from '../common';
+
+interface ClientSearchResultListProps {
+  searchWord: string;
+  productReviews: ProductReviewInfo[];
+}
+
+const ClientSearchResultList = ({
+  searchWord,
+  productReviews = [],
+}: ClientSearchResultListProps) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching } =
+    useInfiniteQuery(searchProductsInfiniteQueryOptions(searchWord));
+
+  const products = useMemo(
+    () => data?.pages.flatMap(page => page.content) || [],
+    [data],
+  );
+
+  const { getReviewInfo } = useProductReviews({
+    initialReviews: productReviews,
+    products,
+  });
+
+  const { groupedRows, totalSize, virtualRows, rowVirtualizer } =
+    useProductListVirtualizer({ products });
+
+  const prefetchNextPage = useCallback(() => {
+    if (hasNextPage && !isFetching && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetching, isFetchingNextPage]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (isFetchingNextPage || !hasNextPage) return;
+
+      const scrollPosition = window.innerHeight + window.scrollY;
+      const threshold = document.documentElement.scrollHeight - 1500;
+
+      if (scrollPosition > threshold) {
+        prefetchNextPage();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [prefetchNextPage, isFetchingNextPage, hasNextPage]);
+
+  return (
+    <>
+      {virtualRows.length === 0 ? (
+        <NoData>{PRODUCTS_CONSTANTS.NO_SEARCH_RESULT}</NoData>
+      ) : (
+        <section className="relative">
+          <div
+            style={{
+              height: `${totalSize}px`,
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            {virtualRows.map(virtualRow => {
+              const rowIndex = virtualRow.index;
+              const rowItems = groupedRows[rowIndex];
+
+              return (
+                <div
+                  key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={rowVirtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualRow.start}px)`,
+                    height: `${virtualRow.size}px`,
+                  }}
+                >
+                  <ul className="gap-x-md grid sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-4">
+                    {rowItems.map((item: Product) => (
+                      <ProductItem
+                        key={item.productId}
+                        {...item}
+                        reviewInfo={getReviewInfo(item.productId)}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+
+          {isFetchingNextPage && <ProductListSkeleton />}
+        </section>
+      )}
+    </>
+  );
+};
+
+export default ClientSearchResultList;

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,0 +1,52 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+
+import { fetchProductReviewInfo } from '@/services';
+import { getQueryClient } from '@/lib';
+import { searchProductsPrefetchInfiniteQueryOptions } from '@/queries';
+import { productServerStore } from '@/stores';
+import { PRODUCTS_CONSTANTS } from '@/constants';
+import type { Product, ProductReviewInfo } from '@/types';
+import ClientSearchResultList from './ClientSearchResultList';
+
+const SearchResultList = async ({ searchWord }: { searchWord: string }) => {
+  const { getParams } = productServerStore();
+  const { cursorId, size } = getParams();
+
+  const queryClient = getQueryClient();
+
+  const initialData = await queryClient.fetchInfiniteQuery(
+    searchProductsPrefetchInfiniteQueryOptions(searchWord, cursorId, size),
+  );
+
+  const allProducts = initialData.pages.flatMap(page => page.content);
+  const productReviews: ProductReviewInfo[] = [];
+
+  await Promise.all(
+    allProducts.map(async (product: Product) => {
+      try {
+        const reviewInfo = await fetchProductReviewInfo(
+          String(product.productId),
+        );
+        productReviews[product.productId] = reviewInfo;
+      } catch (error) {
+        console.error(PRODUCTS_CONSTANTS.FETCH_REVIEW_FAIL_MESSAGE, error);
+        productReviews[product.productId] = {
+          productId: product.productId,
+          avg: '0.0',
+          totalCount: 0,
+        };
+      }
+    }),
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ClientSearchResultList
+        searchWord={searchWord}
+        productReviews={productReviews}
+      />
+    </HydrationBoundary>
+  );
+};
+
+export default SearchResultList;

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,0 +1,2 @@
+export { default as ClientSearchResultList } from './ClientSearchResultList';
+export { default as SearchResultList } from './SearchResultList';

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -37,6 +37,9 @@ export const PRODUCTS_ENDPOINTS = {
     `${API_RESOURCES.PRODUCTS}/${productId}#product-review`,
   RECOMMEND: `${API_RESOURCES.PRODUCTS}/recommend`,
   PAGINATION: `${API_RESOURCES.PRODUCTS}/latest-list/page`,
+  SEARCH: `${API_RESOURCES.PRODUCTS}/search-list`,
+  SEARCH_PAGE: (searchWord: string) =>
+    `${API_RESOURCES.PRODUCTS}?search-word=${encodeURIComponent(searchWord)}`,
 };
 
 export const CART_ENDPOINTS = {

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -34,6 +34,7 @@ export const PRODUCTS_CONSTANTS = {
   OPTION_TYPE: '옵션종류',
   OPTION_TYPE_COUNT: (count: number) => `${count}종류`,
   RELEASE_DATE: '출시년일',
+  SEARCH_PLACEHOLDER: '현재 찾고 싶은 상품을 검색해주세요!',
   SEARCH_RESULT: (keyword: string) => `'${keyword}' 검색 결과`,
   NO_SEARCH_RESULT: '검색 결과가 없습니다.',
 };

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -40,6 +40,7 @@ export const PRODUCTS_CONSTANTS = {
 
 export const PRODUCT_API_ROUTE_MESSAGE = {
   PRODUCT_NOT_FOUND: '상품을 찾을 수 없습니다.',
+  SEARCH_PRODUCT_ERROR: '검색 결과를 불러오는 중 오류가 발생했습니다.',
 };
 
 export const PRODUCT_LIST_LAYOUT_CONFIG = {

--- a/src/constants/products.ts
+++ b/src/constants/products.ts
@@ -34,6 +34,8 @@ export const PRODUCTS_CONSTANTS = {
   OPTION_TYPE: '옵션종류',
   OPTION_TYPE_COUNT: (count: number) => `${count}종류`,
   RELEASE_DATE: '출시년일',
+  SEARCH_RESULT: (keyword: string) => `'${keyword}' 검색 결과`,
+  NO_SEARCH_RESULT: '검색 결과가 없습니다.',
 };
 
 export const PRODUCT_API_ROUTE_MESSAGE = {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -5,3 +5,4 @@ export * from './paymentsQueries';
 export * from './categoryQueries';
 export * from './reviewQueries';
 export * from './memberQueries';
+export * from './searchQueries';

--- a/src/queries/searchQueries.ts
+++ b/src/queries/searchQueries.ts
@@ -1,0 +1,38 @@
+import { infiniteQueryOptions } from '@tanstack/react-query';
+
+import { fetchSearchProductsWithPagination } from '@/services';
+import { PRODUCTS_ENDPOINTS, QUERY_KEYS_ENDPOINT } from '@/constants';
+
+export const searchProductsPrefetchInfiniteQueryOptions = (
+  searchWord: string,
+  cursorId?: number,
+  size = 20,
+) => ({
+  queryKey: [
+    QUERY_KEYS_ENDPOINT.PRODUCTS,
+    PRODUCTS_ENDPOINTS.SEARCH,
+    searchWord,
+  ],
+  queryFn: () => fetchSearchProductsWithPagination(searchWord, cursorId, size),
+  initialPageParam: cursorId,
+});
+
+export const searchProductsInfiniteQueryOptions = (
+  searchWord: string,
+  size = 20,
+) =>
+  infiniteQueryOptions({
+    queryKey: [
+      QUERY_KEYS_ENDPOINT.PRODUCTS,
+      PRODUCTS_ENDPOINTS.SEARCH,
+      searchWord,
+    ],
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) =>
+      fetchSearchProductsWithPagination(searchWord, pageParam, size),
+    getNextPageParam: lastPage =>
+      lastPage.hasNext ? lastPage.nextCursorId : undefined,
+    enabled: !!searchWord,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -37,3 +37,17 @@ export const fetchProductsWithPagination = async (
 
   return response.data;
 };
+
+export const fetchSearchProductsWithPagination = async (
+  keyword: string = '',
+  cursorId?: number,
+  size: number = 20,
+): Promise<PaginatedProductsResponseAPISchema> => {
+  const response = await axiosInstance.post(PRODUCTS_ENDPOINTS.SEARCH, {
+    keyword: keyword,
+    cursorId: cursorId ?? null,
+    size: size,
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

상품 검색 api를 연동하고 검색 결과 페이지를 구현했어요.

## 🔧 변경 사항

- 상품 검색 api 연동
- 무한스크롤의 검색 결과 페이지 구현

## 📸 스크린샷

모바일 환경에서의 검색창 스타일을 추가했어요.

https://github.com/user-attachments/assets/111247a5-a78a-4a20-acd0-897abbc22992

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
