### PR TITLE
[♻️ refactor] page paths의 레거시 상수 PATH_NAME, ROUTER_PATH 제거

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,12 +1,13 @@
+import { AUTH_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { AuthForm } from '@/components';
-import { AUTH_CONSTANTS, ROUTER_PATH } from '@/constants';
 
 const ResetPasswordPage = () => {
   return (
     <AuthForm
       type="resetPw"
       title={AUTH_CONSTANTS.RESET_PW}
-      redirectPath={ROUTER_PATH.LOGIN}
+      redirectPath={pagePath.signin}
     />
   );
 };

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,5 +1,6 @@
+import { AUTH_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { AuthForm, Checkbox, ClickText, SocialLoginButton } from '@/components';
-import { AUTH_CONSTANTS, ROUTER_PATH } from '@/constants';
 
 const { SIGNIN, AUTO_SIGNIN, FORGOT_PW, SOCIAL_SIGNIN, TO_SIGNUP } =
   AUTH_CONSTANTS;
@@ -9,7 +10,7 @@ const SigninPage = () => {
     <AuthForm
       type="signin"
       title={SIGNIN}
-      redirectPath={ROUTER_PATH.HOME}
+      redirectPath={pagePath.home}
       extraFields={<AutoLoginAndResetBox />}
       formFooter={<SocialLoginAndSignupBox />}
     />
@@ -26,7 +27,7 @@ const AutoLoginAndResetBox = () => (
         <div>{AUTO_SIGNIN}</div>
       </div>
       <ClickText
-        href={ROUTER_PATH.RESET_PW}
+        href={pagePath.resetPw}
         className="text-text-info font-style-info"
       >
         {FORGOT_PW}
@@ -46,7 +47,7 @@ const SocialLoginAndSignupBox = () => (
     </div>
     <SocialLoginButton />
     <ClickText
-      href={ROUTER_PATH.SIGNUP}
+      href={pagePath.signup}
       className="text-text-info font-style-info text-center"
     >
       {TO_SIGNUP}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,7 @@
+import { AUTH_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { fetchSignupTerms } from '@/services';
 import { AuthForm } from '@/components';
-import { AUTH_CONSTANTS, ROUTER_PATH } from '@/constants';
 
 const SignupPage = async () => {
   const signupTerms = await fetchSignupTerms();
@@ -9,7 +10,7 @@ const SignupPage = async () => {
     <AuthForm
       type="signup"
       title={AUTH_CONSTANTS.SIGNUP}
-      redirectPath={ROUTER_PATH.LOGIN}
+      redirectPath={pagePath.signin}
       signupTerms={signupTerms}
     />
   );

--- a/src/app/(root)/checkout/not-found.tsx
+++ b/src/app/(root)/checkout/not-found.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link';
 
-import { ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 
 export default function NotFound() {
   return (
     <div>
       <h2>유효하지 않은 정보입니다.</h2>
       <p>장바구니에서 다시 시도해주세요.</p>
-      <Link href={ROUTER_PATH.CART}>Return Home</Link>
+      <Link href={pagePath.cart}>Return Home</Link>
     </div>
   );
 }

--- a/src/app/(root)/checkout/page.tsx
+++ b/src/app/(root)/checkout/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 
-import { PATH_NAME, CHECKOUT_CONSTANT } from '@/constants';
+import { PATH, CHECKOUT_CONSTANT } from '@/constants';
 import { checkoutOrder } from '@/services';
 import {
   CheckoutProductListGroup,
@@ -24,7 +24,7 @@ export async function generateMetadata({ searchParams }: CheckoutPageProps) {
   if (!checkoutRequestItems) return;
 
   return {
-    title: PATH_NAME.ORDER_CHECKOUT,
+    title: PATH.ORDER_CHECKOUT.name,
   };
 }
 

--- a/src/app/(root)/my/orders/[orderId]/page.tsx
+++ b/src/app/(root)/my/orders/[orderId]/page.tsx
@@ -1,4 +1,4 @@
-import { PATH_NAME, ROUTER_PATH } from '@/constants';
+import { PATH } from '@/constants';
 import { fetchOrderDetail } from '@/services';
 import {
   MypageHeader,
@@ -12,7 +12,7 @@ interface Params {
 
 export async function generateMetadata() {
   return {
-    title: PATH_NAME.ORDER_DETAIL,
+    title: PATH.ORDER_DETAIL.name,
   };
 }
 
@@ -21,10 +21,10 @@ const OrderDetailPage = async ({ params }: Params) => {
   const orderDetailInfo = await fetchOrderDetail(orderId);
 
   const linkItems = [
-    { label: PATH_NAME.HOME, href: '' },
-    { label: PATH_NAME.MY_PAGE, href: '' },
-    { label: PATH_NAME.ORDER_HISTORY, href: ROUTER_PATH.ORDERS_HISTORY },
-    { label: PATH_NAME.ORDER_DETAIL, href: `${orderId}`, isCurrent: true },
+    { label: PATH.HOME.name, href: '' },
+    { label: PATH.MY_PAGE.name, href: '' },
+    { label: PATH.ORDER_HISTORY.name, href: PATH.ORDER_HISTORY.url },
+    { label: PATH.ORDER_DETAIL.name, href: `${orderId}`, isCurrent: true },
   ];
 
   const PADDING_STYLES = 'py-3xl';
@@ -32,7 +32,7 @@ const OrderDetailPage = async ({ params }: Params) => {
   return (
     <div className="gap-4xl mx-auto flex flex-col">
       <section className="gap-lg flex flex-col">
-        <MypageHeader linkItems={linkItems} pageName={PATH_NAME.ORDER_DETAIL} />
+        <MypageHeader linkItems={linkItems} pageName={PATH.ORDER_DETAIL.name} />
 
         <section className="gap-5xl flex flex-col">
           <OrderDetailClientWrapper

--- a/src/app/(root)/my/orders/[orderId]/page.tsx
+++ b/src/app/(root)/my/orders/[orderId]/page.tsx
@@ -10,9 +10,11 @@ interface Params {
   params: Promise<{ orderId: string }>;
 }
 
+const { ORDER_HISTORY, ORDER_DETAIL, HOME, MY_PAGE } = PATH;
+
 export async function generateMetadata() {
   return {
-    title: PATH.ORDER_DETAIL.name,
+    title: ORDER_DETAIL.name,
   };
 }
 
@@ -21,10 +23,10 @@ const OrderDetailPage = async ({ params }: Params) => {
   const orderDetailInfo = await fetchOrderDetail(orderId);
 
   const linkItems = [
-    { label: PATH.HOME.name, href: '' },
-    { label: PATH.MY_PAGE.name, href: '' },
-    { label: PATH.ORDER_HISTORY.name, href: PATH.ORDER_HISTORY.url },
-    { label: PATH.ORDER_DETAIL.name, href: `${orderId}`, isCurrent: true },
+    { label: HOME.name, href: '' },
+    { label: MY_PAGE.name, href: '' },
+    { label: ORDER_HISTORY.name, href: ORDER_HISTORY.path },
+    { label: ORDER_DETAIL.name, href: `${orderId}`, isCurrent: true },
   ];
 
   const PADDING_STYLES = 'py-3xl';
@@ -32,7 +34,7 @@ const OrderDetailPage = async ({ params }: Params) => {
   return (
     <div className="gap-4xl mx-auto flex flex-col">
       <section className="gap-lg flex flex-col">
-        <MypageHeader linkItems={linkItems} pageName={PATH.ORDER_DETAIL.name} />
+        <MypageHeader linkItems={linkItems} pageName={ORDER_DETAIL.name} />
 
         <section className="gap-5xl flex flex-col">
           <OrderDetailClientWrapper

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -1,4 +1,5 @@
 import { ORDER_CONSTANT, PATH_NAME, ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import { fetchOrderHistory } from '@/services';
 import { MypageHeader, OrderHistoryClientWrapper, NoData } from '@/components';
 
@@ -12,7 +13,7 @@ const OrderHistoryPage = async () => {
   const initialOrderHistory = await fetchOrderHistory();
 
   const linkItems = [
-    { label: PATH_NAME.HOME, href: ROUTER_PATH.HOME },
+    { label: PATH_NAME.HOME, href: pagePath.home },
     { label: PATH_NAME.MY_PAGE, href: '', isCurrent: true },
     {
       label: PATH_NAME.ORDER_HISTORY,

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -1,11 +1,10 @@
-import { ORDER_CONSTANT, PATH_NAME, ROUTER_PATH } from '@/constants';
-import { pagePath } from '@/navigator';
+import { ORDER_CONSTANT, PATH } from '@/constants';
 import { fetchOrderHistory } from '@/services';
 import { MypageHeader, OrderHistoryClientWrapper, NoData } from '@/components';
 
 export async function generateMetadata() {
   return {
-    title: PATH_NAME.ORDER_HISTORY,
+    title: PATH.ORDER_HISTORY.name,
   };
 }
 
@@ -13,11 +12,11 @@ const OrderHistoryPage = async () => {
   const initialOrderHistory = await fetchOrderHistory();
 
   const linkItems = [
-    { label: PATH_NAME.HOME, href: pagePath.home },
-    { label: PATH_NAME.MY_PAGE, href: '', isCurrent: true },
+    { label: PATH.HOME.name, href: PATH.HOME.url },
+    { label: PATH.MY_PAGE.name, href: '', isCurrent: true },
     {
-      label: PATH_NAME.ORDER_HISTORY,
-      href: ROUTER_PATH.ORDERS_HISTORY,
+      label: PATH.ORDER_HISTORY.name,
+      href: PATH.ORDER_HISTORY.url,
       isCurrent: true,
     },
   ];
@@ -27,7 +26,7 @@ const OrderHistoryPage = async () => {
       <section className="gap-lg flex flex-col">
         <MypageHeader
           linkItems={linkItems}
-          pageName={PATH_NAME.ORDER_HISTORY}
+          pageName={PATH.ORDER_HISTORY.name}
         />
 
         {initialOrderHistory.content.length === 0 ? (

--- a/src/app/(root)/my/orders/page.tsx
+++ b/src/app/(root)/my/orders/page.tsx
@@ -2,9 +2,11 @@ import { ORDER_CONSTANT, PATH } from '@/constants';
 import { fetchOrderHistory } from '@/services';
 import { MypageHeader, OrderHistoryClientWrapper, NoData } from '@/components';
 
+const { ORDER_HISTORY, HOME, MY_PAGE } = PATH;
+
 export async function generateMetadata() {
   return {
-    title: PATH.ORDER_HISTORY.name,
+    title: ORDER_HISTORY.name,
   };
 }
 
@@ -12,11 +14,11 @@ const OrderHistoryPage = async () => {
   const initialOrderHistory = await fetchOrderHistory();
 
   const linkItems = [
-    { label: PATH.HOME.name, href: PATH.HOME.url },
-    { label: PATH.MY_PAGE.name, href: '', isCurrent: true },
+    { label: HOME.name, href: HOME.path },
+    { label: MY_PAGE.name, href: '', isCurrent: true },
     {
-      label: PATH.ORDER_HISTORY.name,
-      href: PATH.ORDER_HISTORY.url,
+      label: ORDER_HISTORY.name,
+      href: ORDER_HISTORY.path,
       isCurrent: true,
     },
   ];
@@ -24,10 +26,7 @@ const OrderHistoryPage = async () => {
   return (
     <div className="gap-4xl mx-auto flex flex-col">
       <section className="gap-lg flex flex-col">
-        <MypageHeader
-          linkItems={linkItems}
-          pageName={PATH.ORDER_HISTORY.name}
-        />
+        <MypageHeader linkItems={linkItems} pageName={ORDER_HISTORY.name} />
 
         {initialOrderHistory.content.length === 0 ? (
           <NoData>

--- a/src/app/error/authorized/page.tsx
+++ b/src/app/error/authorized/page.tsx
@@ -1,5 +1,6 @@
+import { pagePath } from '@/navigator';
+import { ERROR_MESSAGES } from '@/constants';
 import { ErrorPageTemplate } from '@/components';
-import { ERROR_MESSAGES, ROUTER_PATH } from '@/constants';
 
 const { AUTHORIZED_ERROR_PAGE, GO_TO_MAIN_BUTTON } = ERROR_MESSAGES;
 
@@ -10,7 +11,7 @@ const AuthorizedErrorPage = () => {
       subtitle={AUTHORIZED_ERROR_PAGE.SUB_TITLE}
       description={AUTHORIZED_ERROR_PAGE.DESCRIPTIONS}
       buttonText={GO_TO_MAIN_BUTTON}
-      buttonLink={ROUTER_PATH.HOME}
+      buttonLink={pagePath.home}
     />
   );
 };

--- a/src/app/error/restricted/page.tsx
+++ b/src/app/error/restricted/page.tsx
@@ -1,5 +1,6 @@
+import { ERROR_MESSAGES } from '@/constants';
+import { pagePath } from '@/navigator';
 import { ErrorPageTemplate } from '@/components';
-import { ERROR_MESSAGES, ROUTER_PATH } from '@/constants';
 
 const { RESTRICTED_ERROR_PAGE, GO_TO_MAIN_BUTTON } = ERROR_MESSAGES;
 
@@ -10,7 +11,7 @@ const RestrictedErrorPage = () => {
       subtitle={RESTRICTED_ERROR_PAGE.SUB_TITLE}
       description={RESTRICTED_ERROR_PAGE.DESCRIPTIONS}
       buttonText={GO_TO_MAIN_BUTTON}
-      buttonLink={ROUTER_PATH.HOME}
+      buttonLink={pagePath.home}
     />
   );
 };

--- a/src/app/error/unauthorized/page.tsx
+++ b/src/app/error/unauthorized/page.tsx
@@ -1,5 +1,6 @@
+import { ERROR_MESSAGES } from '@/constants';
+import { pagePath } from '@/navigator';
 import { ErrorPageTemplate } from '@/components';
-import { ERROR_MESSAGES, ROUTER_PATH } from '@/constants';
 
 const { UNAUTHORIZED_ERROR_PAGE } = ERROR_MESSAGES;
 
@@ -10,7 +11,7 @@ const UnauthorizedErrorPage = () => {
       subtitle={UNAUTHORIZED_ERROR_PAGE.SUB_TITLE}
       description={UNAUTHORIZED_ERROR_PAGE.DESCRIPTIONS}
       buttonText={UNAUTHORIZED_ERROR_PAGE.GO_TO_LOGIN_BUTTON}
-      buttonLink={ROUTER_PATH.LOGIN}
+      buttonLink={pagePath.signin}
     />
   );
 };

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,6 @@
+import { ERROR_MESSAGES } from '@/constants';
+import { pagePath } from '@/navigator';
 import { ErrorPageTemplate } from '@/components';
-import { ERROR_MESSAGES, ROUTER_PATH } from '@/constants';
 
 const { NOT_FOUND_PAGE, GO_TO_MAIN_BUTTON } = ERROR_MESSAGES;
 
@@ -10,7 +11,7 @@ export default function NotFound() {
       subtitle={NOT_FOUND_PAGE.SUB_TITLE}
       description={NOT_FOUND_PAGE.DESCRIPTIONS}
       buttonText={GO_TO_MAIN_BUTTON}
-      buttonLink={ROUTER_PATH.HOME}
+      buttonLink={pagePath.home}
     />
   );
 }

--- a/src/components/cart/CartInfo.tsx
+++ b/src/components/cart/CartInfo.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 
-import { CART_CONSTANTS, ROUTER_PATH } from '@/constants';
+import { CART_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { cn, formatPrice, toast } from '@/utils';
 import { useCart } from '@/hooks';
 import {
@@ -42,13 +43,13 @@ const CartInfo = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
   const handleCheckoutClick = () => {
     if (!isLoggedIn) {
       toast.warning(CART_TOAST_MESSAGE.LOGIN);
-      router.push(ROUTER_PATH.LOGIN);
+      router.push(pagePath.signin);
       return;
     }
     if (checkedCount === 0) {
       toast.warning(CART_TOAST_MESSAGE.OPTION);
     } else {
-      router.push(ROUTER_PATH.CHECKOUT(encodedCheckoutRequestItems));
+      router.push(pagePath.orderCheckout(encodedCheckoutRequestItems));
     }
   };
 

--- a/src/components/cart/CartItemHeader.tsx
+++ b/src/components/cart/CartItemHeader.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 
-import { ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import { Icon } from '../common';
 
 interface CartItemHeaderProps {
@@ -31,7 +31,7 @@ const CartItemHeader = ({
           <Link href="#">{storeName}</Link>
         </p>
 
-        <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
+        <Link href={pagePath.productDetail(productId)}>
           <h2 className="mb-xs md:mb-sm font-style-subHeading text-text-primary line-clamp-2 text-ellipsis">
             {productName}
           </h2>

--- a/src/components/cart/CartItemImage.tsx
+++ b/src/components/cart/CartItemImage.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 
-import { ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import { Checkbox } from '../common';
 import { ProductThumbnail } from '../products';
 
@@ -32,7 +32,7 @@ const CartItemImage = ({
         />
       </div>
 
-      <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
+      <Link href={pagePath.productDetail(productId)}>
         <ProductThumbnail
           height="h-auto"
           width="w-full"

--- a/src/components/category/ProductCategory.tsx
+++ b/src/components/category/ProductCategory.tsx
@@ -4,9 +4,10 @@ import { useRouter } from 'next/navigation';
 
 import { useQuery } from '@tanstack/react-query';
 
-import { categoryQueryOptions } from '@/queries';
-import { PRODUCTS_CONSTANTS, ROUTER_PATH } from '@/constants';
+import { PRODUCTS_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { cn } from '@/utils';
+import { categoryQueryOptions } from '@/queries';
 import type { CategoryResponseAPISchema } from '@/types';
 import CategorySkeleton from './CategorySkeleton';
 import { Icon } from '../common';
@@ -30,7 +31,7 @@ const ProductCategory = ({
   } = useQuery({ ...categoryQueryOptions, initialData: initialCategories });
 
   const handleCategoryClick = (categoryId: number) => {
-    router.push(ROUTER_PATH.PRODUCT_CATEGORY(String(categoryId)));
+    router.push(pagePath.productCategory(String(categoryId)));
   };
 
   if (isPending) return <CategorySkeleton />;

--- a/src/components/checkout/PaymentMethodSelector.tsx
+++ b/src/components/checkout/PaymentMethodSelector.tsx
@@ -7,9 +7,10 @@ import {
   TossPaymentsWidgets,
 } from '@tosspayments/tosspayments-sdk';
 
+import { CHECKOUT_CONSTANT } from '@/constants';
+import { pagePath } from '@/navigator';
 import { toast } from '@/utils';
 import { requestPayment } from '@/services';
-import { ROUTER_PATH, CHECKOUT_CONSTANT } from '@/constants';
 import { useShippingAddressStore } from '@/stores';
 import type {
   OrderItem,
@@ -153,8 +154,8 @@ const PaymentMethodSelector = ({
       await widgets?.requestPayment({
         orderId: orderSheetNo,
         orderName: orderName,
-        successUrl: `${window.location.origin + ROUTER_PATH.CHECKOUT_SUCCESS}`,
-        failUrl: `${window.location.origin + ROUTER_PATH.CHECKOUT_FAIL}`,
+        successUrl: `${window.location.origin + pagePath.orderCheckoutSuccess}`,
+        failUrl: `${window.location.origin + pagePath.orderCheckoutFail}`,
         customerEmail: recipientEmail,
         customerName: recipientName,
         customerMobilePhone: recipientPhone,

--- a/src/components/common/button/LogoutButton.tsx
+++ b/src/components/common/button/LogoutButton.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import { AUTH_QUERY_KEY, PATH_NAME, QUERY_KEYS_ENDPOINT } from '@/constants';
+import { AUTH_QUERY_KEY, QUERY_KEYS_ENDPOINT, LOGOUT } from '@/constants';
 import { signoutAction } from '@/server-actions';
 import ClickTextButton from './ClickTextButton';
 
@@ -21,9 +21,7 @@ const LogoutButton = () => {
     });
   };
 
-  return (
-    <ClickTextButton onClick={handleLogout}>{PATH_NAME.LOGOUT}</ClickTextButton>
-  );
+  return <ClickTextButton onClick={handleLogout}>{LOGOUT}</ClickTextButton>;
 };
 
 export default LogoutButton;

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 
-import { ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import { SearchInput, Logo, NavIcon, Button } from '@/components';
 import HeaderNavigation from './HeaderNavigation';
 import TextHeader from './TextHeader';
@@ -27,7 +27,7 @@ const Header = ({ isLogin }: HeaderProps) => {
         </nav>
 
         <div className="gap-lg flex items-center justify-between">
-          <Link href={ROUTER_PATH.HOME}>
+          <Link href={pagePath.home}>
             <Logo />
           </Link>
           <div className="hidden flex-1 md:block">

--- a/src/components/layout/header/HeaderNavigation.tsx
+++ b/src/components/layout/header/HeaderNavigation.tsx
@@ -3,17 +3,19 @@ import Link from 'next/link';
 import { PATH } from '@/constants';
 import { NavIcon } from '@/components';
 
+const { COUNTRY_SETTING, CART, MY_PAGE } = PATH;
+
 const HeaderNavigation = () => {
   return (
     <nav className="md:gap-xl gap-md flex">
-      <Link href={PATH.COUNTRY_SETTING.url}>
-        <NavIcon icon="nation" label={PATH.COUNTRY_SETTING.name} />
+      <Link href={COUNTRY_SETTING.path}>
+        <NavIcon icon="nation" label={COUNTRY_SETTING.name} />
       </Link>
-      <Link href={PATH.CART.url}>
-        <NavIcon icon="cart" label={PATH.CART.name} />
+      <Link href={CART.path}>
+        <NavIcon icon="cart" label={CART.name} />
       </Link>
-      <Link href={PATH.MY_PAGE.url}>
-        <NavIcon icon="user" label={PATH.MY_PAGE.name} />
+      <Link href={MY_PAGE.path}>
+        <NavIcon icon="user" label={MY_PAGE.name} />
       </Link>
     </nav>
   );

--- a/src/components/layout/header/HeaderNavigation.tsx
+++ b/src/components/layout/header/HeaderNavigation.tsx
@@ -1,19 +1,19 @@
 import Link from 'next/link';
 
-import { ROUTER_PATH, PATH_NAME } from '@/constants';
+import { PATH } from '@/constants';
 import { NavIcon } from '@/components';
 
 const HeaderNavigation = () => {
   return (
     <nav className="md:gap-xl gap-md flex">
-      <Link href={ROUTER_PATH.COUNTRY_SETTING}>
-        <NavIcon icon="nation" label={PATH_NAME.COUNTRY_SETTING} />
+      <Link href={PATH.COUNTRY_SETTING.url}>
+        <NavIcon icon="nation" label={PATH.COUNTRY_SETTING.name} />
       </Link>
-      <Link href={ROUTER_PATH.CART}>
-        <NavIcon icon="cart" label={PATH_NAME.CART} />
+      <Link href={PATH.CART.url}>
+        <NavIcon icon="cart" label={PATH.CART.name} />
       </Link>
-      <Link href={ROUTER_PATH.MY_PAGE}>
-        <NavIcon icon="user" label={PATH_NAME.MY_PAGE} />
+      <Link href={PATH.MY_PAGE.url}>
+        <NavIcon icon="user" label={PATH.MY_PAGE.name} />
       </Link>
     </nav>
   );

--- a/src/components/layout/header/TextHeader.tsx
+++ b/src/components/layout/header/TextHeader.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { cn } from '@/utils/cn';
-import { ROUTER_PATH, PATH_NAME } from '@/constants';
+import { PATH, CURRENT_COUNTRY } from '@/constants';
 import { ClickText, LogoutButton } from '@/components';
 import { memberDataQueryOptions } from '@/queries';
 
@@ -27,21 +27,21 @@ const TextHeader = ({ isLogin, className = '', country }: TextHeaderProps) => {
 
   const authItems = !memberData
     ? [
-        <ClickText key="login" href={ROUTER_PATH.LOGIN}>
-          {PATH_NAME.LOGIN}
+        <ClickText key="login" href={PATH.SIGNIN.url}>
+          {PATH.SIGNIN.name}
         </ClickText>,
-        <ClickText key="signup" href={ROUTER_PATH.SIGNUP}>
-          {PATH_NAME.SIGNUP}
+        <ClickText key="signup" href={PATH.SIGNUP.url}>
+          {PATH.SIGNUP.name}
         </ClickText>,
       ]
     : [];
 
   const commonItems = [
-    <ClickText key="support" href={ROUTER_PATH.FAQS}>
-      {PATH_NAME.FAQS}
+    <ClickText key="support" href={PATH.FAQS.url}>
+      {PATH.FAQS.name}
     </ClickText>,
     <ClickText key="country" disabled>
-      {PATH_NAME.CURRENT_COUNTRY}({country})
+      {CURRENT_COUNTRY}({country})
     </ClickText>,
   ];
 

--- a/src/components/layout/header/TextHeader.tsx
+++ b/src/components/layout/header/TextHeader.tsx
@@ -27,17 +27,17 @@ const TextHeader = ({ isLogin, className = '', country }: TextHeaderProps) => {
 
   const authItems = !memberData
     ? [
-        <ClickText key="login" href={PATH.SIGNIN.url}>
+        <ClickText key="login" href={PATH.SIGNIN.path}>
           {PATH.SIGNIN.name}
         </ClickText>,
-        <ClickText key="signup" href={PATH.SIGNUP.url}>
+        <ClickText key="signup" href={PATH.SIGNUP.path}>
           {PATH.SIGNUP.name}
         </ClickText>,
       ]
     : [];
 
   const commonItems = [
-    <ClickText key="support" href={PATH.FAQS.url}>
+    <ClickText key="support" href={PATH.FAQS.path}>
       {PATH.FAQS.name}
     </ClickText>,
     <ClickText key="country" disabled>

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryList.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link';
 
 import { cn } from '@/utils';
-import { ORDER_STATUS_LIST, ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
+import { ORDER_STATUS_LIST } from '@/constants';
 import type { OrderItem, OrderStatus } from '@/types';
 import {
   ProductThumbnail,
@@ -47,7 +48,7 @@ const OrderHistoryList = ({
             <div className="gap-4xl flex justify-between">
               <article className="gap-style-orderList flex-1">
                 <div className={THUMB_COLUMN_STYLES}>
-                  <Link href={ROUTER_PATH.PRODUCT_DETAIL(item.productId)}>
+                  <Link href={pagePath.productDetail(item.productId)}>
                     <ProductThumbnail
                       width="w-full"
                       className="aspect-200/175"
@@ -66,7 +67,7 @@ const OrderHistoryList = ({
                   <OrderStatusBadge orderStatus={orderStatus as OrderStatus} />
 
                   <div className="gap-xs flex flex-1 flex-col">
-                    <Link href={ROUTER_PATH.PRODUCT_DETAIL(item.productId)}>
+                    <Link href={pagePath.productDetail(item.productId)}>
                       <ProductName
                         className="w-full"
                         productName={item.productName}

--- a/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
+++ b/src/components/orders-payments/OrderHistoryList/OrderHistoryListGroup.tsx
@@ -5,7 +5,8 @@ import {
   cn,
   formatDateWithSeparator,
 } from '@/utils';
-import { ROUTER_PATH, ORDER_CONSTANT, ORDER_STATUS_LIST } from '@/constants';
+import { pagePath } from '@/navigator';
+import { ORDER_CONSTANT, ORDER_STATUS_LIST } from '@/constants';
 import type { OrderHistoryItem, GroupedOrderItemByOrderId } from '@/types';
 import { OrderGroupHeader, OrderHistoryList, Icon } from '@/components';
 
@@ -44,7 +45,7 @@ const OrderHistoryListGroup = ({
                   <strong>{formatDateWithSeparator(createdAt, '.')}</strong>
 
                   <Link
-                    href={ROUTER_PATH.ORDERS_DETAIL(orderId)}
+                    href={pagePath.orderDetail(orderId)}
                     className="text-text-info flex items-center"
                   >
                     {TEXT_LINK.DETAIL} <Icon iconName="right" />

--- a/src/components/products/ProductItem.tsx
+++ b/src/components/products/ProductItem.tsx
@@ -4,11 +4,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { calculateDiscountRate, formatPrice } from '@/utils';
-import {
-  PRODUCTS_CONSTANTS,
-  PRODUCTS_ENDPOINTS,
-  ROUTER_PATH,
-} from '@/constants';
+import { pagePath } from '@/navigator';
+import { PRODUCTS_CONSTANTS, PRODUCTS_ENDPOINTS } from '@/constants';
 import type { Product, ProductReviewInfo } from '@/types';
 import ProductThumbnail from './ProductThumbnail';
 import { Icon } from '../common';
@@ -27,7 +24,7 @@ const ProductItem = ({
   reviewInfo,
 }: Product & { reviewInfo: ProductReviewInfo }) => {
   const router = useRouter();
-  const productDetailLink = ROUTER_PATH.PRODUCT_DETAIL(productId);
+  const productDetailLink = pagePath.productDetail(productId);
 
   const discountRate =
     originalPrice && sellingPrice

--- a/src/components/products/RecommendProductItem.tsx
+++ b/src/components/products/RecommendProductItem.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import { calculateDiscountRate, formatPrice } from '@/utils';
 import type { Product } from '@/types';
 import ProductThumbnail from './ProductThumbnail';
@@ -19,7 +19,7 @@ const RecommendProductItem = ({
 
   return (
     <li className="px-xs">
-      <Link href={ROUTER_PATH.PRODUCT_DETAIL(productId)}>
+      <Link href={pagePath.productDetail(productId)}>
         <ProductThumbnail
           imageUrl={titleUrl || 'null'}
           name={name}

--- a/src/components/products/product-detail/ProductActions.tsx
+++ b/src/components/products/product-detail/ProductActions.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/navigation';
 
-import { CART_CONSTANTS, PRODUCTS_CONSTANTS, ROUTER_PATH } from '@/constants';
+import { CART_CONSTANTS, PRODUCTS_CONSTANTS } from '@/constants';
+import { pagePath } from '@/navigator';
 import { toast } from '@/utils';
 import { useAddCart } from '@/hooks';
 import { getAccessToken } from '@/services';
@@ -55,11 +56,11 @@ const ProductActions = ({
 
     if (!user) {
       toast.warning(CART_TOAST_MESSAGE.LOGIN);
-      router.push(ROUTER_PATH.LOGIN);
+      router.push(pagePath.signin);
       return;
     }
 
-    router.push(ROUTER_PATH.CHECKOUT(encodedCheckoutRequestItems));
+    router.push(pagePath.orderCheckout(encodedCheckoutRequestItems));
   };
 
   const handleCartClick = async () =>

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -89,22 +89,6 @@ export const PATH_ERROR = {
 export const LOGOUT = '로그아웃';
 export const CURRENT_COUNTRY = '현재 국가';
 
-/**TODO - 기존 레거시 코드 호환, 사용되는 코드 정리 시 제거 */
-export const PATH_NAME = {
-  HOME: PATH.HOME.name,
-  SIGNUP: PATH.SIGNUP.name,
-  LOGIN: PATH.SIGNIN.name,
-  LOGOUT: '로그아웃',
-  FAQS: PATH.FAQS.name,
-  CART: PATH.CART.name,
-  ORDER_CHECKOUT: PATH.ORDER_CHECKOUT.name,
-  ORDER_HISTORY: PATH.ORDER_HISTORY.name,
-  ORDER_DETAIL: PATH.ORDER_DETAIL.name,
-  MY_PAGE: PATH.MY_PAGE.name,
-  CURRENT_COUNTRY: '현재 국가',
-  COUNTRY_SETTING: PATH.COUNTRY_SETTING.name,
-};
-
 /**TODO - 기존 레거시 코드 호환, pageRouter 로 사용 시 제거 */
 export const ROUTER_PATH = {
   HOME: PATH.HOME.url,

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -86,6 +86,9 @@ export const PATH_ERROR = {
   ERROR_RESTRICTED: '/error/restricted',
 };
 
+export const LOGOUT = '로그아웃';
+export const CURRENT_COUNTRY = '현재 국가';
+
 /**TODO - 기존 레거시 코드 호환, 사용되는 코드 정리 시 제거 */
 export const PATH_NAME = {
   HOME: PATH.HOME.name,

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -10,73 +10,73 @@ export const MIDDLE_PATH = {
 export const PATH = {
   HOME: {
     name: '홈',
-    url: '/',
+    path: '/',
   },
   COUNTRY_SETTING: {
     name: '국가설정',
-    url: '/country-setting',
+    path: '/country-setting',
   },
   SIGNUP: {
     name: '회원가입',
-    url: '/signup',
+    path: '/signup',
   },
   SIGNIN: {
     name: '로그인',
-    url: '/signin',
+    path: '/signin',
   },
   RESET_PW: {
     name: '비밀번호 재설정',
-    url: '/reset-password',
+    path: '/reset-password',
   },
   FAQS: {
     name: '자주 묻는 질문',
-    url: '/faqs',
+    path: '/faqs',
   },
   PRODUCT_CATEGORY: {
     name: '상품 카테고리',
-    url: (categoryId: string) =>
+    path: (categoryId: string) =>
       `${MIDDLE_PATH.PRODUCTS}?category=${categoryId}`,
   },
   PRODUCT_DETAIL: {
     name: '상품 상세',
-    url: (productId: number) => `${MIDDLE_PATH.PRODUCTS}/${productId}`,
+    path: (productId: number) => `${MIDDLE_PATH.PRODUCTS}/${productId}`,
   },
   CART: {
     name: '장바구니',
-    url: '/cart',
+    path: '/cart',
   },
   ORDER_CHECKOUT: {
     name: '주문 결제',
-    url: (checkoutRequestItems: string) =>
+    path: (checkoutRequestItems: string) =>
       `${MIDDLE_PATH.CHECKOUT}?checkoutRequestItems=${checkoutRequestItems}`,
   },
   ORDER_CHECKOUT_SUCCESS: {
     name: '주문 성공',
-    url: `${MIDDLE_PATH.CHECKOUT}/success`,
+    path: `${MIDDLE_PATH.CHECKOUT}/success`,
   },
   ORDER_CHECKOUT_FAIL: {
     name: '주문 실패',
-    url: `${MIDDLE_PATH.CHECKOUT}/fail`,
+    path: `${MIDDLE_PATH.CHECKOUT}/fail`,
   },
   ORDER_HISTORY: {
     name: '주문 내역',
-    url: `${MIDDLE_PATH.ORDERS}`,
+    path: `${MIDDLE_PATH.ORDERS}`,
   },
   ORDER_DETAIL: {
     name: '주문 상세',
-    url: (orderId: number) => `${MIDDLE_PATH.ORDERS}/${orderId}`,
+    path: (orderId: number) => `${MIDDLE_PATH.ORDERS}/${orderId}`,
   },
   MY: {
     name: '마이페이지',
-    url: `${MIDDLE_PATH.MY}`,
+    path: `${MIDDLE_PATH.MY}`,
   },
   MY_PAGE: {
     name: '마이페이지',
-    url: `${MIDDLE_PATH.ORDERS}`,
+    path: `${MIDDLE_PATH.ORDERS}`,
   },
   REVIEW_PRODUCT: {
     name: '리뷰 작성',
-    url: (orderId: number, productId: number, productItemId: number) =>
+    path: (orderId: number, productId: number, productItemId: number) =>
       `${MIDDLE_PATH.REVIEW}/write/${orderId}/${productId}/${productItemId}`,
   },
 };

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -1,9 +1,10 @@
-const MIDDLE_PATH = {
+export const MIDDLE_PATH = {
   PRODUCTS: '/products',
   CHECKOUT: '/checkout',
   MY: '/my',
   ORDERS: '/my/orders',
   REVIEW: '/my/review',
+  ERROR: '/error',
 };
 
 export const PATH = {
@@ -81,37 +82,10 @@ export const PATH = {
 };
 
 export const PATH_ERROR = {
-  ERROR_AUTHORIZED: '/error/authorized',
-  ERROR_UNAUTHORIZED: '/error/unauthorized',
-  ERROR_RESTRICTED: '/error/restricted',
+  ERROR_AUTHORIZED: `/${MIDDLE_PATH.ERROR}/authorized`,
+  ERROR_UNAUTHORIZED: `/${MIDDLE_PATH.ERROR}/unauthorized`,
+  ERROR_RESTRICTED: `/${MIDDLE_PATH.ERROR}/restricted`,
 };
 
 export const LOGOUT = '로그아웃';
 export const CURRENT_COUNTRY = '현재 국가';
-
-/**TODO - 기존 레거시 코드 호환, pageRouter 로 사용 시 제거 */
-export const ROUTER_PATH = {
-  HOME: PATH.HOME.url,
-  SIGNUP: PATH.SIGNUP.url,
-  LOGIN: PATH.SIGNIN.url,
-  RESET_PW: PATH.RESET_PW.url,
-  FAQS: PATH.FAQS.url,
-  CART: PATH.CART.url,
-  MY: PATH.MY.url,
-  MY_PAGE: PATH.MY_PAGE.url,
-  COUNTRY_SETTING: PATH.COUNTRY_SETTING.url,
-  CHECKOUT: (checkoutRequestItems: string) =>
-    PATH.ORDER_CHECKOUT.url(checkoutRequestItems),
-  CHECKOUT_SUCCESS: PATH.ORDER_CHECKOUT_SUCCESS.url,
-  CHECKOUT_FAIL: PATH.ORDER_CHECKOUT_FAIL.url,
-  ORDERS_HISTORY: PATH.ORDER_HISTORY.url,
-  ORDERS_DETAIL: (orderId: number) => PATH.ORDER_DETAIL.url(orderId),
-  PRODUCT_DETAIL: (productId: number) => PATH.PRODUCT_DETAIL.url(productId),
-  PRODUCT_CATEGORY: (categoryId: string) =>
-    PATH.PRODUCT_CATEGORY.url(categoryId),
-  REVIEW_PRODUCT: (orderId: number, productId: number, productItemId: number) =>
-    PATH.REVIEW_PRODUCT.url(orderId, productId, productItemId),
-  ERROR_AUTHORIZED: PATH_ERROR.ERROR_AUTHORIZED,
-  ERROR_UNAUTHORIZED: PATH_ERROR.ERROR_UNAUTHORIZED,
-  ERROR_RESTRICTED: PATH_ERROR.ERROR_RESTRICTED,
-};

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -19,7 +19,7 @@ export const PATH = {
     name: '회원가입',
     url: '/signup',
   },
-  LOGIN: {
+  SIGNIN: {
     name: '로그인',
     url: '/signin',
   },
@@ -90,7 +90,7 @@ export const PATH_ERROR = {
 export const PATH_NAME = {
   HOME: PATH.HOME.name,
   SIGNUP: PATH.SIGNUP.name,
-  LOGIN: PATH.LOGIN.name,
+  LOGIN: PATH.SIGNIN.name,
   LOGOUT: '로그아웃',
   FAQS: PATH.FAQS.name,
   CART: PATH.CART.name,
@@ -106,7 +106,7 @@ export const PATH_NAME = {
 export const ROUTER_PATH = {
   HOME: PATH.HOME.url,
   SIGNUP: PATH.SIGNUP.url,
-  LOGIN: PATH.LOGIN.url,
+  LOGIN: PATH.SIGNIN.url,
   RESET_PW: PATH.RESET_PW.url,
   FAQS: PATH.FAQS.url,
   CART: PATH.CART.url,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,18 +1,16 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { BASE_URL, ERROR_MESSAGES, ROUTER_PATH } from '@/constants';
 
-const {
-  ERROR_AUTHORIZED,
-  ERROR_RESTRICTED,
-  ERROR_UNAUTHORIZED,
-  LOGIN,
-  SIGNUP,
-  RESET_PW,
-  MY,
-} = ROUTER_PATH;
+import { BASE_URL, ERROR_MESSAGES, MIDDLE_PATH, PATH_ERROR } from '@/constants';
+import { pagePath } from '@/navigator';
+
+const { signin, signup, resetPw } = pagePath;
+
+const { ERROR_AUTHORIZED, ERROR_RESTRICTED, ERROR_UNAUTHORIZED } = PATH_ERROR;
+
+const { CHECKOUT, ERROR, REVIEW, MY } = MIDDLE_PATH;
 
 const ALLOWED_DOMAINS = [BASE_URL.LOCAL, BASE_URL.SITE];
-const RESTRICTED_PATHS = ['/api', '/checkout', '/error', '/my/review/write'];
+const RESTRICTED_PATHS = ['/api', CHECKOUT, ERROR, `${REVIEW}/write`];
 const ALLOWED_PATHNAME = '/api/auth';
 const RESTRICTED_PATHNAME = '/api';
 const REFERER = 'referer';
@@ -50,7 +48,7 @@ export const middleware = (request: NextRequest) => {
   }
 
   if (accessToken) {
-    if ([LOGIN, SIGNUP, RESET_PW].includes(pathname))
+    if ([signin, signup, resetPw].includes(pathname))
       return NextResponse.redirect(new URL(ERROR_AUTHORIZED, request.url));
   } else if (pathname.startsWith(MY))
     return NextResponse.redirect(new URL(ERROR_UNAUTHORIZED, request.url));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,9 +4,7 @@ import { BASE_URL, ERROR_MESSAGES, MIDDLE_PATH, PATH_ERROR } from '@/constants';
 import { pagePath } from '@/navigator';
 
 const { signin, signup, resetPw } = pagePath;
-
 const { ERROR_AUTHORIZED, ERROR_RESTRICTED, ERROR_UNAUTHORIZED } = PATH_ERROR;
-
 const { CHECKOUT, ERROR, REVIEW, MY } = MIDDLE_PATH;
 
 const ALLOWED_DOMAINS = [BASE_URL.LOCAL, BASE_URL.SITE];

--- a/src/navigator/pagePath.ts
+++ b/src/navigator/pagePath.ts
@@ -4,7 +4,7 @@ const pagePath = {
   home: PATH.HOME.url,
   countrySetting: PATH.COUNTRY_SETTING.url,
   signup: PATH.SIGNUP.url,
-  signin: PATH.LOGIN.url,
+  signin: PATH.SIGNIN.url,
   resetPw: PATH.RESET_PW.url,
   faqs: PATH.FAQS.url,
   myPage: PATH.MY_PAGE.url,

--- a/src/navigator/pagePath.ts
+++ b/src/navigator/pagePath.ts
@@ -1,25 +1,25 @@
 import { PATH } from '@/constants';
 
 const pagePath = {
-  home: PATH.HOME.url,
-  countrySetting: PATH.COUNTRY_SETTING.url,
-  signup: PATH.SIGNUP.url,
-  signin: PATH.SIGNIN.url,
-  resetPw: PATH.RESET_PW.url,
-  faqs: PATH.FAQS.url,
-  myPage: PATH.MY_PAGE.url,
-  orderCheckoutFail: PATH.ORDER_CHECKOUT_FAIL.url,
-  orderCheckoutSuccess: PATH.ORDER_CHECKOUT_SUCCESS.url,
+  home: PATH.HOME.path,
+  countrySetting: PATH.COUNTRY_SETTING.path,
+  signup: PATH.SIGNUP.path,
+  signin: PATH.SIGNIN.path,
+  resetPw: PATH.RESET_PW.path,
+  faqs: PATH.FAQS.path,
+  myPage: PATH.MY_PAGE.path,
+  orderCheckoutFail: PATH.ORDER_CHECKOUT_FAIL.path,
+  orderCheckoutSuccess: PATH.ORDER_CHECKOUT_SUCCESS.path,
   productCategory: (categoryId: string) =>
-    PATH.PRODUCT_CATEGORY.url(categoryId),
-  productDetail: (productId: number) => PATH.PRODUCT_DETAIL.url(productId),
-  cart: PATH.CART.url,
+    PATH.PRODUCT_CATEGORY.path(categoryId),
+  productDetail: (productId: number) => PATH.PRODUCT_DETAIL.path(productId),
+  cart: PATH.CART.path,
   orderCheckout: (checkoutRequestItems: string) =>
-    PATH.ORDER_CHECKOUT.url(checkoutRequestItems),
-  orderHistory: () => PATH.ORDER_HISTORY.url,
-  orderDetail: (orderId: number) => PATH.ORDER_DETAIL.url(orderId),
+    PATH.ORDER_CHECKOUT.path(checkoutRequestItems),
+  orderHistory: () => PATH.ORDER_HISTORY.path,
+  orderDetail: (orderId: number) => PATH.ORDER_DETAIL.path(orderId),
   reviewProduct: (orderId: number, productId: number, productItemId: number) =>
-    PATH.REVIEW_PRODUCT.url(orderId, productId, productItemId),
+    PATH.REVIEW_PRODUCT.path(orderId, productId, productItemId),
 };
 
 export { pagePath };

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -58,12 +58,13 @@ export const CheckoutHeaderComponent: Story = {
   render: () => <CheckoutHeader />,
 };
 
-const linkItems = [
-  { label: PATH.HOME.name, href: PATH.HOME.url },
-  { label: PATH.MY_PAGE.name, href: '', isCurrent: true },
+const { ORDER_HISTORY, HOME, MY_PAGE } = PATH;
+const LINK_ITEMS = [
+  { label: HOME.name, href: HOME.path },
+  { label: MY_PAGE.name, href: '', isCurrent: true },
   {
-    label: PATH.ORDER_HISTORY.name,
-    href: PATH.ORDER_HISTORY.url,
+    label: ORDER_HISTORY.name,
+    href: ORDER_HISTORY.path,
     isCurrent: true,
   },
 ];
@@ -71,6 +72,6 @@ const linkItems = [
 export const MypageHeaderComponent: Story = {
   args: {},
   render: () => (
-    <MypageHeader linkItems={linkItems} pageName={PATH.ORDER_HISTORY.name} />
+    <MypageHeader linkItems={LINK_ITEMS} pageName={ORDER_HISTORY.name} />
   ),
 };

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { PATH_NAME, ROUTER_PATH } from '@/constants';
+import { pagePath } from '@/navigator';
 import {
   PageContentHeader,
   PageTitle,
@@ -59,7 +60,7 @@ export const CheckoutHeaderComponent: Story = {
 };
 
 const linkItems = [
-  { label: PATH_NAME.HOME, href: ROUTER_PATH.HOME },
+  { label: PATH_NAME.HOME, href: pagePath.home },
   { label: PATH_NAME.MY_PAGE, href: '', isCurrent: true },
   {
     label: PATH_NAME.ORDER_HISTORY,

--- a/src/stories/common/PageContentHeader.stories.tsx
+++ b/src/stories/common/PageContentHeader.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { PATH_NAME, ROUTER_PATH } from '@/constants';
-import { pagePath } from '@/navigator';
+import { PATH } from '@/constants';
 import {
   PageContentHeader,
   PageTitle,
@@ -60,11 +59,11 @@ export const CheckoutHeaderComponent: Story = {
 };
 
 const linkItems = [
-  { label: PATH_NAME.HOME, href: pagePath.home },
-  { label: PATH_NAME.MY_PAGE, href: '', isCurrent: true },
+  { label: PATH.HOME.name, href: PATH.HOME.url },
+  { label: PATH.MY_PAGE.name, href: '', isCurrent: true },
   {
-    label: PATH_NAME.ORDER_HISTORY,
-    href: ROUTER_PATH.ORDERS_HISTORY,
+    label: PATH.ORDER_HISTORY.name,
+    href: PATH.ORDER_HISTORY.url,
     isCurrent: true,
   },
 ];
@@ -72,6 +71,6 @@ const linkItems = [
 export const MypageHeaderComponent: Story = {
   args: {},
   render: () => (
-    <MypageHeader linkItems={linkItems} pageName={PATH_NAME.ORDER_HISTORY} />
+    <MypageHeader linkItems={linkItems} pageName={PATH.ORDER_HISTORY.name} />
   ),
 };

--- a/src/stories/layout/header/NavIcon.stories.tsx
+++ b/src/stories/layout/header/NavIcon.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { NavIcon } from '@/components';
-import { PATH_NAME } from '@/constants';
+import { PATH } from '@/constants';
 
 const meta = {
   title: 'Layout/Header/NavIcon',
@@ -28,20 +28,20 @@ type Story = StoryObj<typeof meta>;
 export const CountrySetting: Story = {
   args: {
     icon: 'nation',
-    label: PATH_NAME.COUNTRY_SETTING,
+    label: PATH.COUNTRY_SETTING.name,
   },
 };
 
 export const Cart: Story = {
   args: {
     icon: 'cart',
-    label: PATH_NAME.CART,
+    label: PATH.CART.name,
   },
 };
 
 export const MyPage: Story = {
   args: {
     icon: 'user',
-    label: PATH_NAME.MY_PAGE,
+    label: PATH.MY_PAGE.name,
   },
 };

--- a/src/utils/genertate.ts
+++ b/src/utils/genertate.ts
@@ -17,9 +17,9 @@ export const getOrderItemsWithExpectedArrivalAt = (orderItems: OrderItem[]) =>
 /** PATH 상수에서 URL에 해당하는 이름 찾기 */
 export const getNameFromPath = (path: string): string => {
   const pathEntry = Object.entries(PATH).find(([, pathItem]) => {
-    if (typeof pathItem.url === 'function') return false;
+    if (typeof pathItem.path === 'function') return false;
 
-    return pathItem.url === path;
+    return pathItem.path === path;
   });
 
   if (!pathEntry) {
@@ -45,7 +45,7 @@ export const generateBreadcrumbItems = (
   // 항상 홈 링크로 시작
   const homeItem: BreadcrumbItem = {
     label: homeLabel,
-    href: PATH.HOME.url,
+    href: PATH.HOME.path,
     isCurrent: pathSegments.length === 0,
   };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
기존 페이지의 페이지 경로 이동의 상수모듈을 구조화하였으나 기존 페이지 라우팅 호환을 위한 레거시 코드가 남아있기 때문에 레거시 상수를 제거할 수 있도록 리팩토링을 완료했어요
 
## 🔧 변경 사항

- 기존 페이지 라우팅 호환을 위한 레거시 코드 `PATH_NAME`, `ROUTER_PATH`를 제거했어요
- 단순 페이지 라우팅이 필요해 import 힐 경우 navigator의 pagePath를 import 해서 적용했어요
- 페이지의 경로와 페이지 이름 모두 import 할 경우는 가독성을 고려해 구조화된 PATH 상수를 import 해서 사용했어요

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

- 미들웨어의 config matcher 에 포함되는 경로들도 import 한 상수를 활용하고 싶었지만 빌드타임에서 에러가 생기기 때문에 적용할 수 없었어요. 

  ```bash
  ⨯ Next.js can't recognize the exported `config` field in route "/src/middleware":
  Unknown identifier "signin" at "config.matcher[0]".
  Read More - https://nextjs.org/docs/messages/invalid-page-config
  ```
  ![image](https://github.com/user-attachments/assets/d95750fb-7154-47a7-ac4f-2d3cc7eef05d)

- Azure에 호스팅된 백엔드 서버가 현재 중지 돼서 pnpm run build 결과가 실패하고 있어요. 그 이유는 상품 상세페이지 `/products/[productId]] `에서  `generateStaticParams` 함수를 사용해 정적으로 빌드 타임에 해당 API를 호출하여 데이터를 가져오기 떄문이에요.

  ![image](https://github.com/user-attachments/assets/c5b1a508-1916-4e02-bda8-513e19fdc172)
  ![image](https://github.com/user-attachments/assets/12b93a4b-c892-4f77-bd9a-8bd4d9210742)
  ... html 생략
  ![image](https://github.com/user-attachments/assets/c644438a-c781-425a-a780-67d98b07040d)
